### PR TITLE
feat(repo): add repository scan history management and UI integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Code Style: Comments Required
 
-The author has extensive Java/Golang/Python experience but is new to Swift and macOS app development. All generated code must include detailed comments in Chinese explaining:
+The author has extensive Java/Golang/Python experience but is new to Swift and macOS app development. All generated code must include detailed comments in **English** explaining:
 - Swift-specific syntax and language features (e.g., `@Observable`, `actor`, `some View`, property wrappers)
 - SwiftUI concepts and view lifecycle (e.g., `.task`, `.environment()`, `NavigationSplitView`)
 - macOS/Apple platform APIs (e.g., `NSWorkspace`, `DispatchSource`, `FileManager`)

--- a/Sources/SkillDeck/ViewModels/SkillInstallViewModel.swift
+++ b/Sources/SkillDeck/ViewModels/SkillInstallViewModel.swift
@@ -83,8 +83,8 @@ final class SkillInstallViewModel: Identifiable {
     /// 已成功安装的 skill 数量
     var installedCount = 0
 
-    /// 合并去重后的 repo 历史记录（来自 lock file + scan 历史）
-    /// 在 ViewModel 创建后通过 loadHistory() 异步加载
+    /// Merged and deduplicated repo history (from lock file + scan history)
+    /// Loaded asynchronously via loadHistory() after ViewModel creation
     var repoHistory: [(source: String, sourceUrl: String)] = []
 
     // MARK: - Dependencies
@@ -110,24 +110,24 @@ final class SkillInstallViewModel: Identifiable {
 
     // MARK: - Actions
 
-    /// 加载 repo 历史记录（合并 lock file + scan 历史）
+    /// Load repo history (merged from lock file + scan history)
     ///
-    /// 在 View 的 .task 修饰符中调用（不在 init 中调用，因为 init 是同步的，
-    /// 而 getRepoHistory 是 async 方法需要 await）。
-    /// .task 在视图首次出现时自动执行异步代码，类似 Android 的 onResume + coroutine
+    /// Called from the View's .task modifier (not in init, because init is synchronous
+    /// while getRepoHistory is async and requires await).
+    /// .task runs async code when the view first appears, similar to Android's onResume + coroutine
     func loadHistory() async {
         repoHistory = await skillManager.getRepoHistory()
     }
 
-    /// 选择一条历史记录：自动填入 URL 并触发 Scan
+    /// Select a history entry: auto-fill URL input and trigger Scan
     ///
-    /// 用户在 Install Sheet 的历史列表中点击某条记录时调用。
-    /// 直接使用 sourceUrl（完整 URL）作为输入，然后自动执行 fetchRepository()。
+    /// Called when the user taps a row in the Install Sheet's history list.
+    /// Uses the source (owner/repo) format as input — fetchRepository() will normalize it internally.
     ///
-    /// - Parameter source: 仓库来源标识（如 "crossoverJie/skills"）
-    /// - Parameter sourceUrl: 完整仓库 URL（如 "https://github.com/crossoverJie/skills.git"）
+    /// - Parameter source: Repo source identifier (e.g. "crossoverJie/skills")
+    /// - Parameter sourceUrl: Full repo URL (e.g. "https://github.com/crossoverJie/skills.git")
     func selectHistoryRepo(source: String, sourceUrl: String) async {
-        // 使用 source 格式（owner/repo）作为输入，fetchRepository 内部会 normalize
+        // Use source format (owner/repo) as input; fetchRepository normalizes it internally
         repoURLInput = source
         await fetchRepository()
     }
@@ -181,7 +181,7 @@ final class SkillInstallViewModel: Identifiable {
             // 默认选中所有未安装的 skill
             selectedSkillNames = Set(discovered.map(\.id).filter { !alreadyInstalledNames.contains($0) })
 
-            // 保存 scan 历史记录（下次打开 Install Sheet 时可以快速选择）
+            // Save scan history (so this repo appears in "Recent Repositories" next time)
             await skillManager.saveRepoHistory(source: normalizedSource, sourceUrl: normalizedRepoURL)
 
             // 6. 转到选择阶段

--- a/Sources/SkillDeck/Views/Install/SkillInstallView.swift
+++ b/Sources/SkillDeck/Views/Install/SkillInstallView.swift
@@ -107,8 +107,8 @@ struct SkillInstallView: View {
             }
             .padding(.horizontal, 40)
 
-            // 历史记录列表：仅当 repoHistory 非空时显示
-            // 用户可以点击历史项快速填入 URL 并自动 Scan
+            // History list: only shown when repoHistory is not empty
+            // Users can click a history item to auto-fill the URL and trigger Scan
             if !viewModel.repoHistory.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Recent Repositories")
@@ -116,15 +116,15 @@ struct SkillInstallView: View {
                         .foregroundStyle(.secondary)
                         .padding(.horizontal, 40)
 
-                    // ScrollView 包裹历史列表，防止条目过多时撑开整个视图
-                    // .frame(maxHeight: 150) 限制最大高度，超出时可滚动
+                    // ScrollView wraps the history list to prevent too many entries from stretching the view
+                    // .frame(maxHeight: 150) caps the height; content scrolls if it overflows
                     ScrollView {
                         VStack(spacing: 0) {
-                            // ForEach 需要 Identifiable 或提供 id 参数
-                            // 这里用 source 字段作为唯一标识（已去重）
+                            // ForEach requires Identifiable or an explicit id parameter
+                            // Here we use source as the unique identifier (already deduplicated)
                             ForEach(viewModel.repoHistory, id: \.source) { entry in
                                 Button {
-                                    // 点击历史项：自动填入 URL 并触发 Scan
+                                    // Click a history item: auto-fill URL and trigger Scan
                                     Task {
                                         await viewModel.selectHistoryRepo(
                                             source: entry.source,
@@ -133,7 +133,7 @@ struct SkillInstallView: View {
                                     }
                                 } label: {
                                     HStack(spacing: 8) {
-                                        // 时钟箭头图标，表示"历史记录"
+                                        // Clock arrow icon representing "history"
                                         Image(systemName: "clock.arrow.circlepath")
                                             .foregroundStyle(.secondary)
                                             .font(.caption)
@@ -144,12 +144,12 @@ struct SkillInstallView: View {
                                     }
                                     .padding(.vertical, 6)
                                     .padding(.horizontal, 12)
-                                    // contentShape 扩大可点击区域到整行（默认只有文字可点击）
+                                    // contentShape expands the tappable area to the full row (by default only text is tappable)
                                     .contentShape(Rectangle())
                                 }
                                 .buttonStyle(.plain)
 
-                                // 行与行之间的分隔线（最后一行不显示）
+                                // Divider between rows (skip the last row)
                                 if entry.source != viewModel.repoHistory.last?.source {
                                     Divider()
                                         .padding(.leading, 32)
@@ -166,8 +166,8 @@ struct SkillInstallView: View {
             Spacer()
         }
         .padding()
-        // .task 在视图首次出现时执行异步代码（类似 Android onResume + coroutine）
-        // 用于加载 repo 历史记录
+        // .task runs async code when the view first appears (like Android onResume + coroutine)
+        // Used here to load repo history
         .task {
             await viewModel.loadHistory()
         }


### PR DESCRIPTION

  - Save scanned GitHub repos to persistent history in ~/.agents/.skilldeck-cache.json
  - Display "Recent Repositories" list in Install Sheet for quick re-scanning
  - Merge lock file installed repos + scan history with case-insensitive dedup