### PR TITLE
feat: add Cursor agent support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Views → ViewModels (@Observable) → SkillManager (@Observable) → Services (
 | Gemini CLI | `~/.gemini/skills/` | `gemini` binary |
 | Copilot CLI | `~/.copilot/skills/` | `gh` binary |
 | Antigravity | `~/.gemini/antigravity/skills/` | `antigravity` binary |
+| Cursor | `~/.cursor/skills/` | `cursor` binary |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ---
 
-**SkillDeck** is the first desktop GUI for managing skills across multiple AI code agents — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line), and [Antigravity](https://antigravity.google). No more manual file editing, symlink juggling, or YAML parsing by hand.
+**SkillDeck** is the first desktop GUI for managing skills across multiple AI code agents — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line), [Antigravity](https://antigravity.google), and [Cursor](https://cursor.com). No more manual file editing, symlink juggling, or YAML parsing by hand.
 
 ## Screenshots
 
@@ -40,7 +40,7 @@
 
 ## Features
 
-- **Multi-Agent Support** — Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity
+- **Multi-Agent Support** — Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor
 - **Registry Browser** — Browse [skills.sh](https://skills.sh) leaderboard (All Time, Trending, Hot) and search the catalog
 - **Unified Dashboard** — All skills in one three-pane macOS-native view
 - **One-Click Install** — Clone from GitHub, auto-create symlinks and update lock file
@@ -99,6 +99,7 @@ swift test
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/skills/` | `gemini` binary + `~/.gemini/` dir |
 | [Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line) | `~/.copilot/skills/` | `gh` binary |
 | [Antigravity](https://antigravity.google) | `~/.gemini/antigravity/skills/` | `antigravity` binary |
+| [Cursor](https://cursor.com) | `~/.cursor/skills/` | `cursor` binary |
 
 ## Architecture
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -22,7 +22,7 @@
 
 ---
 
-**SkillDeck** 是首个用于管理多个 AI 代码代理技能的桌面 GUI 工具，支持 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex](https://github.com/openai/codex)、[Gemini CLI](https://github.com/google-gemini/gemini-cli)、[Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line) 和 [Antigravity](https://antigravity.google)。告别手动编辑文件、管理符号链接和手工解析 YAML。
+**SkillDeck** 是首个用于管理多个 AI 代码代理技能的桌面 GUI 工具，支持 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex](https://github.com/openai/codex)、[Gemini CLI](https://github.com/google-gemini/gemini-cli)、[Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line)、[Antigravity](https://antigravity.google) 和 [Cursor](https://cursor.com)。告别手动编辑文件、管理符号链接和手工解析 YAML。
 
 ## 截图
 
@@ -38,7 +38,7 @@
 
 ## 功能特性
 
-- **多代理支持** — Claude Code、Codex、Gemini CLI、Copilot CLI、OpenCode、Antigravity
+- **多代理支持** — Claude Code、Codex、Gemini CLI、Copilot CLI、OpenCode、Antigravity、Cursor
 - **技能市场浏览** — 浏览 [skills.sh](https://skills.sh) 排行榜（全部时间、趋势、热门）并搜索技能目录
 - **统一仪表盘** — 所有技能集中在一个 macOS 原生三栏视图中
 - **一键安装** — 从 GitHub 克隆，自动创建符号链接并更新锁文件
@@ -97,6 +97,7 @@ swift test
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/skills/` | `gemini` 二进制文件 + `~/.gemini/` 目录 |
 | [Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line) | `~/.copilot/skills/` | `gh` 二进制文件 |
 | [Antigravity](https://antigravity.google) | `~/.gemini/antigravity/skills/` | `antigravity` 二进制文件 |
+| [Cursor](https://cursor.com) | `~/.cursor/skills/` | `cursor` 二进制文件 |
 
 ## 架构
 

--- a/Sources/SkillDeck/Models/AgentType.swift
+++ b/Sources/SkillDeck/Models/AgentType.swift
@@ -9,6 +9,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
     case copilotCLI = "copilot-cli"
     case openCode = "opencode"       // OpenCode: Open source AI programming CLI tool
     case antigravity = "antigravity"   // Antigravity: Google's AI coding agent (https://antigravity.google)
+    case cursor = "cursor"               // Cursor: AI-powered code editor (https://cursor.com)
 
     // Identifiable protocol requirement (similar to Java's Comparable), needed for SwiftUI list rendering
     var id: String { rawValue }
@@ -21,6 +22,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .copilotCLI: "Copilot CLI"
         case .openCode: "OpenCode"
         case .antigravity: "Antigravity"
+        case .cursor: "Cursor"
         }
     }
 
@@ -34,6 +36,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .copilotCLI: "purple"
         case .openCode: "teal"
         case .antigravity: "indigo"
+        case .cursor: "cyan"
         }
     }
 
@@ -47,6 +50,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .copilotCLI: "airplane"
         case .openCode: "chevron.left.forwardslash.chevron.right"  // </> Code symbol, fitting OpenCode's programming theme
         case .antigravity: "arrow.up.circle"  // Upward motion symbolizing anti-gravity
+        case .cursor: "cursorarrow.rays"        // Cursor arrow icon matching the Cursor IDE brand
         }
     }
 
@@ -60,6 +64,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .copilotCLI: "~/.copilot/skills"
         case .openCode: "~/.config/opencode/skills"  // OpenCode uses XDG-style configuration path
         case .antigravity: "~/.gemini/antigravity/skills"  // Antigravity stores skills under Gemini's config directory
+        case .cursor: "~/.cursor/skills"                    // Cursor IDE skills directory
         }
     }
 
@@ -78,6 +83,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .copilotCLI: "~/.copilot"
         case .openCode: "~/.config/opencode"
         case .antigravity: "~/.gemini/antigravity"
+        case .cursor: "~/.cursor"
         }
     }
 
@@ -90,6 +96,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .copilotCLI: "gh"
         case .openCode: "opencode"
         case .antigravity: "antigravity"
+        case .cursor: "cursor"
         }
     }
 
@@ -116,6 +123,9 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
                 (AgentType.claudeCode.skillsDirectoryURL, .claudeCode),
                 (AgentType.codex.skillsDirectoryURL, .codex)
             ]
+        case .cursor:
+            // Cursor can also read Claude Code's skills directory
+            return [(AgentType.claudeCode.skillsDirectoryURL, .claudeCode)]
         default:
             return []
         }

--- a/Sources/SkillDeck/Utilities/Constants.swift
+++ b/Sources/SkillDeck/Utilities/Constants.swift
@@ -16,6 +16,7 @@ enum Constants {
             case .copilotCLI: Color(red: 0.58, green: 0.34, blue: 0.92)   // Purple
             case .openCode:   Color(red: 0.0, green: 0.71, blue: 0.67)    // Teal #00B5AB
             case .antigravity: Color(red: 0.36, green: 0.42, blue: 0.75)  // Indigo #5C6BC0
+            case .cursor:      Color(red: 0.06, green: 0.73, blue: 0.89)  // Cyan #10BAE3
             }
         }
     }

--- a/Tests/SkillDeckTests/AgentTypeTests.swift
+++ b/Tests/SkillDeckTests/AgentTypeTests.swift
@@ -28,12 +28,33 @@ final class AgentTypeTests: XCTestCase {
         XCTAssertTrue(agent.additionalReadableSkillsDirectories.isEmpty)
     }
 
+    // MARK: - Cursor Agent Properties
+
+    /// Verify all computed properties of the Cursor agent type
+    func testCursorProperties() {
+        let agent = AgentType.cursor
+
+        // rawValue is used as the Codable key in lock file JSON
+        XCTAssertEqual(agent.rawValue, "cursor")
+        XCTAssertEqual(agent.displayName, "Cursor")
+        XCTAssertEqual(agent.detectCommand, "cursor")
+        XCTAssertEqual(agent.skillsDirectoryPath, "~/.cursor/skills")
+        XCTAssertEqual(agent.configDirectoryPath, "~/.cursor")
+        XCTAssertEqual(agent.iconName, "cursorarrow.rays")
+        XCTAssertEqual(agent.brandColor, "cyan")
+
+        // Cursor reads Claude Code's skills directory as an additional source
+        let additionalDirs = agent.additionalReadableSkillsDirectories
+        XCTAssertEqual(additionalDirs.count, 1)
+        XCTAssertEqual(additionalDirs[0].sourceAgent, .claudeCode)
+    }
+
     // MARK: - CaseIterable Count
 
     /// Verify the total number of supported agents
     /// This test catches accidental removal of agent cases
     func testAllCasesCount() {
-        // 6 agents: claudeCode, codex, geminiCLI, copilotCLI, openCode, antigravity
-        XCTAssertEqual(AgentType.allCases.count, 6)
+        // 7 agents: claudeCode, codex, geminiCLI, copilotCLI, openCode, antigravity, cursor
+        XCTAssertEqual(AgentType.allCases.count, 7)
     }
 }

--- a/docs/AGENT-CROSS-DIRECTORY-GUIDE.md
+++ b/docs/AGENT-CROSS-DIRECTORY-GUIDE.md
@@ -29,9 +29,10 @@ Claude Code  → ~/.claude/skills/
 Copilot CLI  → ~/.copilot/skills/
 Gemini CLI   → ~/.gemini/skills/
 Antigravity  → ~/.gemini/antigravity/skills/
+Cursor       → ~/.cursor/skills/
 ```
 
-但某些 Agent 会额外读取其他 Agent 的目录。例如 Copilot CLI 同时读取 `~/.copilot/skills/` 和 `~/.claude/skills/`。
+但某些 Agent 会额外读取其他 Agent 的目录。例如 Copilot CLI 同时读取 `~/.copilot/skills/` 和 `~/.claude/skills/`，Cursor 同时读取 `~/.cursor/skills/` 和 `~/.claude/skills/`。
 
 ### 继承安装的定义
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -19,7 +19,7 @@
 | Feature | Description |
 |---------|-------------|
 | Auto-Detect Agents | Detects installed agents via CLI binaries and config directories |
-| Multi-Agent Support | Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity |
+| Multi-Agent Support | Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor |
 | Agent Status Indicators | Sidebar shows skill count per agent; uninstalled agents shown dimmed |
 | Agent Assignment | Toggle switches to install/uninstall a skill to specific agents (auto-manages symlinks) |
 | Inherited Installation Protection | Inherited cross-agent installations are labeled with their source and toggle-disabled |
@@ -86,7 +86,7 @@
 
 ### v0.1 MVP (Done)
 
-- [x] **F01 — Agent Detection**: Auto-detect installed agents (Claude Code, Codex, Gemini CLI, Copilot CLI, Antigravity) by checking config directories and CLI binaries
+- [x] **F01 — Agent Detection**: Auto-detect installed agents (Claude Code, Codex, Gemini CLI, Copilot CLI, Antigravity, Cursor) by checking config directories and CLI binaries
 - [x] **F02 — Unified Dashboard**: Single view of all skills across agents and scopes, with symlink deduplication
 - [x] **F03 — Skill Detail View**: Parse and render SKILL.md (YAML frontmatter + markdown body)
 - [x] **F04 — Skill Deletion**: Delete skill directory + remove symlinks + update `.skill-lock.json`

--- a/docs/index.html
+++ b/docs/index.html
@@ -549,7 +549,7 @@
             <div class="container">
                 <div class="hero-content">
                     <h1>MANAGE AI AGENT SKILLS LIKE A BOSS</h1>
-                    <p>The first desktop GUI for managing skills across Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, and Antigravity. No more manual file editing or symlink juggling.</p>
+                    <p>The first desktop GUI for managing skills across Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, and Cursor. No more manual file editing or symlink juggling.</p>
                     <div class="hero-cta">
                         <a href="https://github.com/crossoverJie/SkillDeck/releases" class="btn btn-primary">
                             <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -567,7 +567,7 @@
             <div class="container">
                 <div class="stats-grid">
                     <div class="stat-card">
-                        <span class="stat-number">6</span>
+                        <span class="stat-number">7</span>
                         <span class="stat-label">Supported Agents</span>
                     </div>
                     <div class="stat-card">
@@ -614,7 +614,7 @@
                             </svg>
                         </div>
                         <h3>Multi-Agent Support</h3>
-                        <p>Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity — all in one place.</p>
+                        <p>Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor — all in one place.</p>
                     </div>
                     <div class="feature-card">
                         <div class="feature-icon" style="background: var(--secondary);">
@@ -694,6 +694,10 @@
                     <div class="agent-card">
                         <span class="agent-emoji">🚀</span>
                         <h3>Antigravity</h3>
+                    </div>
+                    <div class="agent-card">
+                        <span class="agent-emoji">🖱️</span>
+                        <h3>Cursor</h3>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- Add Cursor IDE as the 7th supported agent in SkillDeck
- Cursor reads skills from `~/.cursor/skills/` and additionally reads `~/.claude/skills/` (cross-directory, shown as "via Claude Code")
- Detection via `cursor` CLI binary, brand color cyan (#10BAE3), SF Symbol `cursorarrow.rays`

Closes #10

## Changes (9 files)

**Source (2):**
- `AgentType.swift` — new `cursor` enum case + all 7 switch statements
- `Constants.swift` — cyan brand color

**Tests (1):**
- `AgentTypeTests.swift` — `testCursorProperties()` + count 6→7

**Docs (6):**
- `CLAUDE.md`, `README.md`, `README_CN.md`, `FEATURES.md`, `AGENT-CROSS-DIRECTORY-GUIDE.md`, `index.html`

## Manual Verification Required

- Verify Cursor agent appears in the sidebar with correct icon and cyan color
- Verify skills from `~/.claude/skills/` show as "via Claude Code" under Cursor agent (toggle disabled, dimmed icon)
- Verify the `cursorarrow.rays` SF Symbol renders correctly on macOS 14+

## Regression Checklist

- [x] Existing agents (Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity) still appear correctly in sidebar
- [x] Agent toggle switches still work for all existing agents
- [x] Cross-directory "via" behavior still works for Copilot CLI and OpenCode
- [x] Skill installation/deletion still functions correctly
- [x] Dashboard skill count badges are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)