### PR TITLE
feat: add OpenClaw agent support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ Views → ViewModels (@Observable) → SkillManager (@Observable) → Services (
 | Antigravity | `~/.gemini/antigravity/skills/` | `antigravity` binary | Own directory only |
 | Cursor | `~/.cursor/skills/` | `cursor` binary | Own → `~/.claude/skills/` |
 | Kiro | `~/.kiro/skills/` | `kiro` binary | Own directory only |
+| OpenClaw | `~/.openclaw/skills/` | `openclaw` binary | Own directory only |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ---
 
-**SkillDeck** is the first desktop GUI for managing skills across multiple AI code agents — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line), [Antigravity](https://antigravity.google), [Cursor](https://cursor.com), and [Kiro](https://kiro.dev). No more manual file editing, symlink juggling, or YAML parsing by hand.
+**SkillDeck** is the first desktop GUI for managing skills across multiple AI code agents — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line), [Antigravity](https://antigravity.google), [Cursor](https://cursor.com), [Kiro](https://kiro.dev), and [OpenClaw](https://openclaw.ai). No more manual file editing, symlink juggling, or YAML parsing by hand.
 
 ## Screenshots
 
@@ -40,7 +40,7 @@
 
 ## Features
 
-- **Multi-Agent Support** — Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor, Kiro
+- **Multi-Agent Support** — Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor, Kiro, OpenClaw
 - **Registry Browser** — Browse [skills.sh](https://skills.sh) leaderboard (All Time, Trending, Hot) and search the catalog
 - **Unified Dashboard** — All skills in one three-pane macOS-native view
 - **One-Click Install** — Clone from GitHub, auto-create symlinks and update lock file
@@ -102,6 +102,7 @@ swift test
 | [Antigravity](https://antigravity.google) | `~/.gemini/antigravity/skills/` | `antigravity` binary | Own directory only |
 | [Cursor](https://cursor.com) | `~/.cursor/skills/` | `cursor` binary | Own → `~/.claude/skills/` |
 | [Kiro](https://kiro.dev) | `~/.kiro/skills/` | `kiro` binary | Own directory only |
+| [OpenClaw](https://openclaw.ai) | `~/.openclaw/skills/` | `openclaw` binary | Own directory only |
 
 ## Architecture
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -22,7 +22,7 @@
 
 ---
 
-**SkillDeck** 是首个用于管理多个 AI 代码代理技能的桌面 GUI 工具，支持 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex](https://github.com/openai/codex)、[Gemini CLI](https://github.com/google-gemini/gemini-cli)、[Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line)、[Antigravity](https://antigravity.google)、[Cursor](https://cursor.com) 和 [Kiro](https://kiro.dev)。告别手动编辑文件、管理符号链接和手工解析 YAML。
+**SkillDeck** 是首个用于管理多个 AI 代码代理技能的桌面 GUI 工具，支持 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex](https://github.com/openai/codex)、[Gemini CLI](https://github.com/google-gemini/gemini-cli)、[Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line)、[Antigravity](https://antigravity.google)、[Cursor](https://cursor.com)、[Kiro](https://kiro.dev) 和 [OpenClaw](https://openclaw.ai)。告别手动编辑文件、管理符号链接和手工解析 YAML。
 
 ## 截图
 
@@ -38,7 +38,7 @@
 
 ## 功能特性
 
-- **多代理支持** — Claude Code、Codex、Gemini CLI、Copilot CLI、OpenCode、Antigravity、Cursor、Kiro
+- **多代理支持** — Claude Code、Codex、Gemini CLI、Copilot CLI、OpenCode、Antigravity、Cursor、Kiro、OpenClaw
 - **技能市场浏览** — 浏览 [skills.sh](https://skills.sh) 排行榜（全部时间、趋势、热门）并搜索技能目录
 - **统一仪表盘** — 所有技能集中在一个 macOS 原生三栏视图中
 - **一键安装** — 从 GitHub 克隆，自动创建符号链接并更新锁文件
@@ -100,6 +100,7 @@ swift test
 | [Antigravity](https://antigravity.google) | `~/.gemini/antigravity/skills/` | `antigravity` 二进制文件 | 仅自身目录 |
 | [Cursor](https://cursor.com) | `~/.cursor/skills/` | `cursor` 二进制文件 | 自身 → `~/.claude/skills/` |
 | [Kiro](https://kiro.dev) | `~/.kiro/skills/` | `kiro` 二进制文件 | 仅自身目录 |
+| [OpenClaw](https://openclaw.ai) | `~/.openclaw/skills/` | `openclaw` 二进制文件 | 仅自身目录 |
 
 ## 架构
 

--- a/Sources/SkillDeck/Models/AgentType.swift
+++ b/Sources/SkillDeck/Models/AgentType.swift
@@ -11,6 +11,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
     case antigravity = "antigravity"   // Antigravity: Google's AI coding agent (https://antigravity.google)
     case cursor = "cursor"               // Cursor: AI-powered code editor (https://cursor.com)
     case kiro = "kiro"                     // Kiro: AWS AI IDE built on Code OSS (https://kiro.dev)
+    case openClaw = "openclaw"             // OpenClaw: AI coding assistant with ClawHub registry (https://openclaw.ai)
 
     // Identifiable protocol requirement (similar to Java's Comparable), needed for SwiftUI list rendering
     var id: String { rawValue }
@@ -25,6 +26,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .antigravity: "Antigravity"
         case .cursor: "Cursor"
         case .kiro: "Kiro"
+        case .openClaw: "OpenClaw"
         }
     }
 
@@ -40,6 +42,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .antigravity: "indigo"
         case .cursor: "cyan"
         case .kiro: "violet"
+        case .openClaw: "red"
         }
     }
 
@@ -55,6 +58,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .antigravity: "arrow.up.circle"  // Upward motion symbolizing anti-gravity
         case .cursor: "cursorarrow.rays"        // Cursor arrow icon matching the Cursor IDE brand
         case .kiro: "k.circle"                   // Letter K icon for Kiro
+        case .openClaw: "o.circle"               // Letter O icon for OpenClaw
         }
     }
 
@@ -70,6 +74,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .antigravity: "~/.gemini/antigravity/skills"  // Antigravity stores skills under Gemini's config directory
         case .cursor: "~/.cursor/skills"                    // Cursor IDE skills directory
         case .kiro: "~/.kiro/skills"                       // Kiro IDE skills directory
+        case .openClaw: "~/.openclaw/skills"               // OpenClaw AI assistant skills directory
         }
     }
 
@@ -90,6 +95,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .antigravity: "~/.gemini/antigravity"
         case .cursor: "~/.cursor"
         case .kiro: "~/.kiro"
+        case .openClaw: "~/.openclaw"
         }
     }
 
@@ -104,6 +110,7 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .antigravity: "antigravity"
         case .cursor: "cursor"
         case .kiro: "kiro"
+        case .openClaw: "openclaw"
         }
     }
 

--- a/Sources/SkillDeck/Utilities/Constants.swift
+++ b/Sources/SkillDeck/Utilities/Constants.swift
@@ -18,6 +18,7 @@ enum Constants {
             case .antigravity: Color(red: 0.36, green: 0.42, blue: 0.75)  // Indigo #5C6BC0
             case .cursor:      Color(red: 0.06, green: 0.73, blue: 0.89)  // Cyan #10BAE3
             case .kiro:        Color(red: 0.55, green: 0.24, blue: 0.85)  // Violet
+            case .openClaw:    Color(red: 0.85, green: 0.18, blue: 0.15)  // Red #D92E26 (lobster/crayfish theme)
             }
         }
     }

--- a/Tests/SkillDeckTests/AgentTypeTests.swift
+++ b/Tests/SkillDeckTests/AgentTypeTests.swift
@@ -89,12 +89,31 @@ final class AgentTypeTests: XCTestCase {
         XCTAssertTrue(agent.additionalReadableSkillsDirectories.isEmpty)
     }
 
+    // MARK: - OpenClaw Agent Properties
+
+    /// Verify all computed properties of the OpenClaw agent type
+    func testOpenClawProperties() {
+        let agent = AgentType.openClaw
+
+        // rawValue is used as the Codable key in lock file JSON
+        XCTAssertEqual(agent.rawValue, "openclaw")
+        XCTAssertEqual(agent.displayName, "OpenClaw")
+        XCTAssertEqual(agent.detectCommand, "openclaw")
+        XCTAssertEqual(agent.skillsDirectoryPath, "~/.openclaw/skills")
+        XCTAssertEqual(agent.configDirectoryPath, "~/.openclaw")
+        XCTAssertEqual(agent.iconName, "o.circle")
+        XCTAssertEqual(agent.brandColor, "red")
+
+        // OpenClaw does not read other agents' directories
+        XCTAssertTrue(agent.additionalReadableSkillsDirectories.isEmpty)
+    }
+
     // MARK: - CaseIterable Count
 
     /// Verify the total number of supported agents
     /// This test catches accidental removal of agent cases
     func testAllCasesCount() {
-        // 8 agents: claudeCode, codex, geminiCLI, copilotCLI, openCode, antigravity, cursor, kiro
-        XCTAssertEqual(AgentType.allCases.count, 8)
+        // 9 agents: claudeCode, codex, geminiCLI, copilotCLI, openCode, antigravity, cursor, kiro, openClaw
+        XCTAssertEqual(AgentType.allCases.count, 9)
     }
 }

--- a/docs/AGENT-CROSS-DIRECTORY-GUIDE.md
+++ b/docs/AGENT-CROSS-DIRECTORY-GUIDE.md
@@ -31,6 +31,7 @@ Gemini CLI   → ~/.gemini/skills/
 Antigravity  → ~/.gemini/antigravity/skills/
 Cursor       → ~/.cursor/skills/
 Kiro         → ~/.kiro/skills/
+OpenClaw     → ~/.openclaw/skills/
 ```
 
 但某些 Agent 会额外读取其他 Agent 的目录。例如 Copilot CLI 同时读取 `~/.copilot/skills/` 和 `~/.claude/skills/`，Cursor 同时读取 `~/.cursor/skills/` 和 `~/.claude/skills/`。

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -19,7 +19,7 @@
 | Feature | Description |
 |---------|-------------|
 | Auto-Detect Agents | Detects installed agents via CLI binaries and config directories |
-| Multi-Agent Support | Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor, Kiro |
+| Multi-Agent Support | Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor, Kiro, OpenClaw |
 | Agent Status Indicators | Sidebar shows skill count per agent; uninstalled agents shown dimmed |
 | Agent Assignment | Toggle switches to install/uninstall a skill to specific agents (auto-manages symlinks) |
 | Inherited Installation Protection | Inherited cross-agent installations are labeled with their source and toggle-disabled |
@@ -86,7 +86,7 @@
 
 ### v0.1 MVP (Done)
 
-- [x] **F01 — Agent Detection**: Auto-detect installed agents (Claude Code, Codex, Gemini CLI, Copilot CLI, Antigravity, Cursor, Kiro) by checking config directories and CLI binaries
+- [x] **F01 — Agent Detection**: Auto-detect installed agents (Claude Code, Codex, Gemini CLI, Copilot CLI, Antigravity, Cursor, Kiro, OpenClaw) by checking config directories and CLI binaries
 - [x] **F02 — Unified Dashboard**: Single view of all skills across agents and scopes, with symlink deduplication
 - [x] **F03 — Skill Detail View**: Parse and render SKILL.md (YAML frontmatter + markdown body)
 - [x] **F04 — Skill Deletion**: Delete skill directory + remove symlinks + update `.skill-lock.json`

--- a/docs/index.html
+++ b/docs/index.html
@@ -549,7 +549,7 @@
             <div class="container">
                 <div class="hero-content">
                     <h1>MANAGE AI AGENT SKILLS LIKE A BOSS</h1>
-                    <p>The first desktop GUI for managing skills across Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor, and Kiro. No more manual file editing or symlink juggling.</p>
+                    <p>The first desktop GUI for managing skills across Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor, Kiro, and OpenClaw. No more manual file editing or symlink juggling.</p>
                     <div class="hero-cta">
                         <a href="https://github.com/crossoverJie/SkillDeck/releases" class="btn btn-primary">
                             <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -567,7 +567,7 @@
             <div class="container">
                 <div class="stats-grid">
                     <div class="stat-card">
-                        <span class="stat-number">8</span>
+                        <span class="stat-number">9</span>
                         <span class="stat-label">Supported Agents</span>
                     </div>
                     <div class="stat-card">
@@ -614,7 +614,7 @@
                             </svg>
                         </div>
                         <h3>Multi-Agent Support</h3>
-                        <p>Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor, Kiro — all in one place.</p>
+                        <p>Claude Code, Codex, Gemini CLI, Copilot CLI, OpenCode, Antigravity, Cursor, Kiro, OpenClaw — all in one place.</p>
                     </div>
                     <div class="feature-card">
                         <div class="feature-icon" style="background: var(--secondary);">
@@ -702,6 +702,10 @@
                     <div class="agent-card">
                         <span class="agent-emoji">🪁</span>
                         <h3>Kiro</h3>
+                    </div>
+                    <div class="agent-card">
+                        <span class="agent-emoji">🦞</span>
+                        <h3>OpenClaw</h3>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add OpenClaw (AI coding assistant with ClawHub registry) as the 9th supported agent
- Skills directory: `~/.openclaw/skills/`, CLI detection: `openclaw` binary, brand color: red (#D92E26)
- Updated 9 files: 2 source + 1 test + 6 docs

## Manual Verification Required
- Launch the app and verify OpenClaw appears in the sidebar agent list with the correct red brand color
- Verify the `o.circle` SF Symbol icon renders correctly for OpenClaw
- If `openclaw` CLI is installed, verify it is detected as "installed" in the sidebar

## Regression Checklist
- [ ] All existing 8 agents still appear correctly in the sidebar with correct icons, colors, and badge counts
- [ ] Agent toggle switches still work for installing/uninstalling skills to agents
- [ ] Cross-directory reading (Copilot→Claude, Cursor→Claude, OpenCode→Claude/shared) still functions
- [ ] Skill installation, deletion, and update flows are unaffected
- [ ] Registry browser and one-click install still work


🤖 Generated with [Claude Code](https://claude.com/claude-code)