### PR TITLE
feat: add local directory import for skills

### DIFF
--- a/Sources/SkillDeck/Services/SkillMDParser.swift
+++ b/Sources/SkillDeck/Services/SkillMDParser.swift
@@ -78,12 +78,15 @@ enum SkillMDParser {
 
         // Parse YAML string into SkillMetadata using Yams library
         // YAMLDecoder is similar to Java's ObjectMapper or Go's json.Unmarshal
-        let decoder = YAMLDecoder()
         let metadata: SkillMetadata
         do {
+            let decoder = YAMLDecoder()
             metadata = try decoder.decode(SkillMetadata.self, from: yamlString)
         } catch {
-            throw ParseError.invalidYAML(error.localizedDescription)
+            // Fallback: when strict Codable decoding fails (e.g., description contains ": "
+            // which Yams misinterprets as a nested mapping key), try raw YAML parsing.
+            // Yams.load() returns an untyped dictionary, more lenient with ambiguous values.
+            metadata = try parseYAMLFallback(yamlString)
         }
 
         return ParseResult(metadata: metadata, markdownBody: body.trimmingCharacters(in: .whitespacesAndNewlines))
@@ -113,6 +116,95 @@ enum SkillMDParser {
         let body = String(rest[bodyStart...])
 
         return (yamlString, body)
+    }
+
+    /// Fallback YAML parser: line-by-line extraction for SKILL.md frontmatter
+    ///
+    /// When YAMLDecoder.decode() fails (e.g., a colon ": " inside a description value
+    /// is misinterpreted as a YAML mapping key by the scanner), this method uses
+    /// simple line-by-line parsing to extract key-value pairs.
+    ///
+    /// SKILL.md frontmatter is typically flat (no deep nesting), so line-by-line parsing
+    /// is sufficient. The only nested structure is `metadata:` with `author:` and `version:`.
+    ///
+    /// Why not quote-preprocess + re-parse? Because Yams scanner rejects the raw YAML
+    /// before any decoding happens — Yams.load() also fails on ambiguous `: `.
+    private static func parseYAMLFallback(_ yamlString: String) throws -> SkillMetadata {
+        // Parse line by line, building a flat [String: String] and a nested metadata dict
+        var fields: [String: String] = [:]
+        var metadataExtra: [String: String] = [:]
+        // Track whether we're inside the `metadata:` block (indented sub-keys)
+        var inMetadataBlock = false
+
+        for line in yamlString.components(separatedBy: .newlines) {
+            let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+
+            // Skip empty lines and comments
+            if trimmedLine.isEmpty || trimmedLine.hasPrefix("#") { continue }
+
+            // Check if line is indented (part of a nested block like `metadata:`)
+            // In YAML, nested keys are indented with spaces relative to parent
+            let isIndented = line.hasPrefix("  ") || line.hasPrefix("\t")
+
+            if isIndented && inMetadataBlock {
+                // Parse indented key-value under `metadata:` block
+                if let colonIndex = trimmedLine.firstIndex(of: ":") {
+                    let key = String(trimmedLine[trimmedLine.startIndex..<colonIndex])
+                        .trimmingCharacters(in: .whitespaces)
+                    let value = String(trimmedLine[trimmedLine.index(after: colonIndex)...])
+                        .trimmingCharacters(in: .whitespaces)
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+                    metadataExtra[key] = value
+                }
+                continue
+            }
+
+            // Non-indented line: exit metadata block
+            inMetadataBlock = false
+
+            // Parse top-level key: value
+            // Only split on the FIRST colon (so "desc: foo: bar" → key="desc", value="foo: bar")
+            guard let colonIndex = trimmedLine.firstIndex(of: ":") else { continue }
+            let key = String(trimmedLine[trimmedLine.startIndex..<colonIndex])
+                .trimmingCharacters(in: .whitespaces)
+            let value = String(trimmedLine[trimmedLine.index(after: colonIndex)...])
+                .trimmingCharacters(in: .whitespaces)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+
+            if key == "metadata" && value.isEmpty {
+                // Start of `metadata:` nested block
+                inMetadataBlock = true
+                continue
+            }
+
+            fields[key] = value
+        }
+
+        // Build SkillMetadata from extracted fields
+        guard let name = fields["name"], !name.isEmpty else {
+            throw ParseError.invalidYAML("Missing required field: name")
+        }
+        guard let description = fields["description"], !description.isEmpty else {
+            throw ParseError.invalidYAML("Missing required field: description")
+        }
+
+        // Handle YAML folded/literal scalar indicators (> or |) in description
+        // For simple fallback, the description is already extracted as-is
+        var metadataObj: SkillMetadata.MetadataExtra?
+        if !metadataExtra.isEmpty {
+            metadataObj = SkillMetadata.MetadataExtra(
+                author: metadataExtra["author"],
+                version: metadataExtra["version"]
+            )
+        }
+
+        return SkillMetadata(
+            name: name,
+            description: description,
+            license: fields["license"],
+            metadata: metadataObj,
+            allowedTools: fields["allowed-tools"] ?? fields["allowedTools"]
+        )
     }
 
     /// Serialize SkillMetadata back to SKILL.md format string

--- a/Sources/SkillDeck/Services/SkillManager.swift
+++ b/Sources/SkillDeck/Services/SkillManager.swift
@@ -37,6 +37,28 @@ final class SkillManager {
         }
     }
 
+    /// Error types for importing local skill directories
+    /// Each case represents a specific validation failure during the import flow
+    enum ImportError: Error, LocalizedError {
+        /// The specified directory does not exist on disk
+        case directoryNotFound(String)
+        /// No SKILL.md file found inside the directory
+        case skillMDNotFound(String)
+        /// SKILL.md exists but could not be parsed (invalid YAML frontmatter or format)
+        case parseFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .directoryNotFound(let path):
+                "Directory not found: \(path)"
+            case .skillMDNotFound(let path):
+                "No SKILL.md found in: \(path)"
+            case .parseFailed(let message):
+                "Failed to parse SKILL.md: \(message)"
+            }
+        }
+    }
+
     // MARK: - Published State (UI-bound state)
 
     /// All discovered skills (deduplicated)
@@ -353,6 +375,95 @@ final class SkillManager {
         await refresh()
     }
 
+    // MARK: - Local Import
+
+    /// Import a skill from a local directory on the filesystem
+    ///
+    /// Flow:
+    /// 1. Validate the source directory exists and contains a parseable SKILL.md
+    /// 2. Copy the entire directory to canonical path (~/.agents/skills/<skillName>/)
+    /// 3. Create symlinks for selected Agents
+    /// 4. Update lock file with sourceType "local" and source = original directory path
+    /// 5. Refresh UI
+    ///
+    /// Unlike installSkill (GitHub-based), local imports have no git hash or remote URL.
+    /// The lock entry uses sourceType "local" so that checkAllUpdates() can skip them
+    /// (local directories have no remote to compare against).
+    ///
+    /// - Parameters:
+    ///   - sourceURL: Local directory URL containing SKILL.md
+    ///   - skillName: Name for the skill (typically the directory name)
+    ///   - targetAgents: Set of Agents to create symlinks for
+    func importLocalSkill(
+        from sourceURL: URL,
+        skillName: String,
+        targetAgents: Set<AgentType>
+    ) async throws {
+        let fm = FileManager.default
+
+        // 1. Validate source directory exists
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: sourceURL.path, isDirectory: &isDir), isDir.boolValue else {
+            throw ImportError.directoryNotFound(sourceURL.path)
+        }
+
+        // 2. Validate SKILL.md exists and is parseable
+        let skillMDURL = sourceURL.appendingPathComponent("SKILL.md")
+        guard fm.fileExists(atPath: skillMDURL.path) else {
+            throw ImportError.skillMDNotFound(sourceURL.path)
+        }
+
+        do {
+            // Attempt to parse SKILL.md to verify it's valid
+            // SkillMDParser.parse(fileURL:) reads the file and parses YAML frontmatter + markdown body
+            _ = try SkillMDParser.parse(fileURL: skillMDURL)
+        } catch {
+            throw ImportError.parseFailed(error.localizedDescription)
+        }
+
+        // 3. Copy directory to canonical path (~/.agents/skills/<skillName>/)
+        let canonicalDir = SkillScanner.sharedSkillsURL.appendingPathComponent(skillName)
+
+        // If already exists, delete first then copy (overwrite import)
+        if fm.fileExists(atPath: canonicalDir.path) {
+            try fm.removeItem(at: canonicalDir)
+        }
+
+        // Ensure parent directory (~/.agents/skills/) exists
+        if !fm.fileExists(atPath: SkillScanner.sharedSkillsURL.path) {
+            try fm.createDirectory(at: SkillScanner.sharedSkillsURL, withIntermediateDirectories: true)
+        }
+
+        // copyItem is like cp -r, recursively copies entire directory
+        try fm.copyItem(at: sourceURL, to: canonicalDir)
+
+        // 4. Create symlinks for selected Agents
+        for agent in targetAgents {
+            // Use try? to ignore existing symlink errors (idempotent operation)
+            try? SymlinkManager.createSymlink(from: canonicalDir, to: agent)
+        }
+
+        // 5. Update lock file with sourceType "local"
+        // Ensure lock file exists (may not exist on first import)
+        try await lockFileManager.createIfNotExists()
+
+        // ISO 8601 timestamp (consistent with npx skills CLI format)
+        let now = ISO8601DateFormatter().string(from: Date())
+        let entry = LockEntry(
+            source: sourceURL.path,
+            sourceType: "local",
+            sourceUrl: sourceURL.path,
+            skillPath: "\(skillName)/SKILL.md",
+            skillFolderHash: "",  // Local imports have no git hash
+            installedAt: now,
+            updatedAt: now
+        )
+        try await lockFileManager.updateEntry(skillName: skillName, entry: entry)
+
+        // 6. Refresh UI
+        await refresh()
+    }
+
     // MARK: - F12: Update Check
 
     /// Check for updates for a single skill
@@ -427,8 +538,10 @@ final class SkillManager {
         defer { isCheckingUpdates = false }
 
         // Collect all skills with lockEntry, group by sourceUrl
+        // Skip local imports: they have no remote repository to compare against,
+        // and trying to git-clone a local filesystem path would cause errors
         // Dictionary(grouping:by:) is similar to Java Stream's Collectors.groupingBy()
-        let skillsWithLock = skills.filter { $0.lockEntry != nil }
+        let skillsWithLock = skills.filter { $0.lockEntry != nil && $0.lockEntry?.sourceType != "local" }
 
         // Set all skills to be checked to .checking state
         // So UI list immediately shows spinner, user knows which skills are being checked

--- a/Sources/SkillDeck/ViewModels/LocalImportViewModel.swift
+++ b/Sources/SkillDeck/ViewModels/LocalImportViewModel.swift
@@ -1,0 +1,240 @@
+import Foundation
+import AppKit
+
+/// LocalImportViewModel manages the state and logic for importing skills from local directories
+///
+/// Import flow consists of phases (finite state machine):
+/// 1. selectPath — User picks a local directory via NSOpenPanel
+/// 2. validating — Verify directory contains a valid SKILL.md
+/// 3. selectAgents — User selects target Agents to install the skill to
+/// 4. importing — Copy files and create symlinks
+/// 5. completed — Import finished successfully
+/// 6. error — Something went wrong, show error message
+///
+/// @MainActor ensures all properties update on the main thread (UI-bound state must be on main thread)
+/// @Observable enables SwiftUI to automatically track property changes and refresh views
+@MainActor
+@Observable
+/// Identifiable protocol requires a unique id property so `.sheet(item:)` can use it to determine
+/// when to show/hide the sheet (item != nil → show, nil → hide)
+final class LocalImportViewModel: Identifiable {
+
+    /// Unique identifier, required property for Identifiable protocol
+    let id = UUID()
+
+    // MARK: - Phase Enum
+
+    /// Import flow phases (finite state machine)
+    /// Similar to Java enum, but Swift enum can have associated values (like Rust's enum variants)
+    enum Phase: Equatable {
+        /// Initial phase: waiting for user to select a local directory
+        case selectPath
+        /// Validating the selected directory (checking for SKILL.md, parsing)
+        case validating
+        /// Directory validated, waiting for user to select target Agents
+        case selectAgents
+        /// Importing skill (copying files, creating symlinks)
+        case importing
+        /// Import completed successfully
+        case completed
+        /// Error occurred, with error message attached
+        case error(String)
+
+        // Manual Equatable: error case compares message content
+        static func == (lhs: Phase, rhs: Phase) -> Bool {
+            switch (lhs, rhs) {
+            case (.selectPath, .selectPath),
+                 (.validating, .validating),
+                 (.selectAgents, .selectAgents),
+                 (.importing, .importing),
+                 (.completed, .completed):
+                return true
+            case (.error(let a), .error(let b)):
+                return a == b
+            default:
+                return false
+            }
+        }
+    }
+
+    // MARK: - State
+
+    /// Current import flow phase
+    var phase: Phase = .selectPath
+
+    /// URL of the directory selected by the user (nil until a folder is picked)
+    var selectedDirectoryURL: URL?
+
+    /// Parsed metadata from the SKILL.md in the selected directory
+    /// Populated during validation phase, used for preview display
+    var skillMetadata: SkillMetadata?
+
+    /// Skill name derived from the directory name (used as the canonical skill identifier)
+    var skillName: String = ""
+
+    /// Whether a skill with the same name already exists in the canonical directory
+    /// When true, the UI shows a warning that the existing skill will be overwritten
+    var alreadyExists: Bool = false
+
+    /// Set of target Agents selected by user (Claude Code selected by default)
+    var selectedAgents: Set<AgentType> = [.claudeCode]
+
+    /// Progress message displayed during validating/importing phases
+    var progressMessage = ""
+
+    // MARK: - Dependencies
+
+    /// SkillManager reference, used to execute the import and check existing skills
+    private let skillManager: SkillManager
+
+    // MARK: - Init
+
+    init(skillManager: SkillManager) {
+        self.skillManager = skillManager
+    }
+
+    // MARK: - Actions
+
+    /// Show macOS native folder picker (NSOpenPanel) for user to select a skill directory
+    ///
+    /// NSOpenPanel is AppKit's file/folder selection dialog (similar to JFileChooser in Java Swing).
+    /// Configured to allow selecting both files and directories:
+    /// - If user selects a directory, use it directly
+    /// - If user selects a SKILL.md file, resolve to its parent directory
+    ///
+    /// After selection, automatically triggers validation
+    func openFolderPicker() {
+        // NSOpenPanel must be created and run on the main thread (AppKit requirement)
+        let panel = NSOpenPanel()
+        // Allow selecting directories (the primary use case)
+        panel.canChooseDirectories = true
+        // Also allow selecting files (so user can pick SKILL.md directly)
+        panel.canChooseFiles = true
+        // Only allow single selection
+        panel.allowsMultipleSelection = false
+        // Dialog title and button text
+        panel.title = "Select Skill Directory"
+        panel.prompt = "Select"
+        // Hint message shown at the top of the dialog
+        panel.message = "Choose a directory containing SKILL.md, or select a SKILL.md file directly"
+        // Show hidden files/directories (those starting with '.') so users can navigate into
+        // paths like ~/.claude/skills/ or ~/.agents/skills/ which are common skill locations
+        panel.showsHiddenFiles = true
+
+        // runModal() shows the dialog and blocks until user confirms or cancels
+        // Returns .OK if user clicked "Select", .cancel if user clicked "Cancel"
+        let response = panel.runModal()
+        guard response == .OK, let url = panel.url else { return }
+
+        // If user selected a SKILL.md file, resolve to its parent directory
+        // lastPathComponent returns the filename portion of the URL path
+        if url.lastPathComponent == "SKILL.md" {
+            selectedDirectoryURL = url.deletingLastPathComponent()
+        } else {
+            selectedDirectoryURL = url
+        }
+
+        // Auto-trigger validation after selection
+        Task { await validateDirectory() }
+    }
+
+    /// Validate the selected directory contains a parseable SKILL.md
+    ///
+    /// Checks:
+    /// 1. Directory exists on disk
+    /// 2. Contains a SKILL.md file
+    /// 3. SKILL.md is parseable (valid YAML frontmatter)
+    ///
+    /// On success, populates skillMetadata, skillName, and alreadyExists,
+    /// then transitions to .selectAgents phase
+    func validateDirectory() async {
+        guard let dirURL = selectedDirectoryURL else {
+            phase = .error("No directory selected")
+            return
+        }
+
+        phase = .validating
+        progressMessage = "Validating directory..."
+
+        let fm = FileManager.default
+
+        // 1. Check directory exists
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: dirURL.path, isDirectory: &isDir), isDir.boolValue else {
+            phase = .error("Selected path is not a valid directory: \(dirURL.path)")
+            return
+        }
+
+        // 2. Check SKILL.md exists
+        let skillMDURL = dirURL.appendingPathComponent("SKILL.md")
+        guard fm.fileExists(atPath: skillMDURL.path) else {
+            phase = .error("No SKILL.md found in the selected directory")
+            return
+        }
+
+        // 3. Parse SKILL.md
+        do {
+            let result = try SkillMDParser.parse(fileURL: skillMDURL)
+            skillMetadata = result.metadata
+        } catch {
+            phase = .error("Failed to parse SKILL.md: \(error.localizedDescription)")
+            return
+        }
+
+        // Derive skill name from directory name (e.g., "agent-notifier")
+        // lastPathComponent extracts the final path segment, equivalent to Go's filepath.Base()
+        skillName = dirURL.lastPathComponent
+
+        // Check if a skill with the same name already exists
+        alreadyExists = skillManager.skills.contains { $0.id == skillName }
+
+        // Validation passed, transition to agent selection phase
+        phase = .selectAgents
+    }
+
+    /// Execute the import: copy files, create symlinks, update lock file
+    ///
+    /// Delegates to SkillManager.importLocalSkill() which handles all the heavy lifting.
+    /// Transitions to .completed on success, .error on failure.
+    func importSkill() async {
+        guard let dirURL = selectedDirectoryURL else {
+            phase = .error("No directory selected")
+            return
+        }
+
+        phase = .importing
+        progressMessage = "Importing \(skillName)..."
+
+        do {
+            try await skillManager.importLocalSkill(
+                from: dirURL,
+                skillName: skillName,
+                targetAgents: selectedAgents
+            )
+            phase = .completed
+        } catch {
+            phase = .error(error.localizedDescription)
+        }
+    }
+
+    /// Toggle selection state of an Agent
+    /// If the Agent is already selected, remove it; otherwise, add it
+    func toggleAgentSelection(_ agent: AgentType) {
+        if selectedAgents.contains(agent) {
+            selectedAgents.remove(agent)
+        } else {
+            selectedAgents.insert(agent)
+        }
+    }
+
+    /// Reset to initial state (start over for importing another skill)
+    func reset() {
+        phase = .selectPath
+        selectedDirectoryURL = nil
+        skillMetadata = nil
+        skillName = ""
+        alreadyExists = false
+        selectedAgents = [.claudeCode]
+        progressMessage = ""
+    }
+}

--- a/Sources/SkillDeck/Views/Install/LocalImportView.swift
+++ b/Sources/SkillDeck/Views/Install/LocalImportView.swift
@@ -1,0 +1,279 @@
+import SwiftUI
+
+/// LocalImportView is the sheet UI for importing skills from local directories
+///
+/// Follows the same layout pattern as SkillInstallView:
+/// VStack with headerBar + phase-switched content, displayed as a .sheet() modal.
+///
+/// Phase flow: selectPath → validating → selectAgents → importing → completed | error
+struct LocalImportView: View {
+
+    /// ViewModel manages the import process state
+    /// @Bindable allows @Observable object properties to create Binding (two-way binding)
+    @Bindable var viewModel: LocalImportViewModel
+
+    /// Get dismiss action from environment, used to close sheet
+    /// @Environment(\.dismiss) is SwiftUI's standard way to close currently presented view
+    @Environment(\.dismiss) private var dismiss
+
+    /// Get SkillManager from environment (for checking detected Agents)
+    @Environment(SkillManager.self) private var skillManager
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header bar (common to all phases)
+            headerBar
+
+            Divider()
+
+            // Display different content based on current phase
+            // Swift's switch is an expression, can be used directly in ViewBuilder
+            switch viewModel.phase {
+            case .selectPath:
+                selectPathPhase
+            case .validating:
+                validatingPhase
+            case .selectAgents:
+                selectAgentsPhase
+            case .importing:
+                importingPhase
+            case .completed:
+                completedPhase
+            case .error(let message):
+                errorPhase(message)
+            }
+        }
+        // Sheet modal minimum size (macOS standard practice)
+        .frame(minWidth: 500, minHeight: 350)
+    }
+
+    // MARK: - Header
+
+    /// Header bar with title and close button (common to all phases)
+    private var headerBar: some View {
+        HStack {
+            Text("Import Local Skill")
+                .font(.headline)
+            Spacer()
+            // Close button
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding()
+    }
+
+    // MARK: - Phase Views
+
+    /// Phase 1: Select a local directory
+    /// Shows a folder icon, description text, and a "Select Folder..." button
+    private var selectPathPhase: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            // Folder icon (large, decorative)
+            Image(systemName: "folder.badge.plus")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text("Select a local directory containing SKILL.md")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            // "Select Folder..." button triggers NSOpenPanel
+            Button("Select Folder...") {
+                viewModel.openFolderPicker()
+            }
+            .buttonStyle(.borderedProminent)
+
+            Spacer()
+        }
+        .padding()
+    }
+
+    /// Phase: Validating directory (shows spinner)
+    private var validatingPhase: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            // ProgressView is macOS native loading indicator (spinning spinner)
+            ProgressView()
+                .controlSize(.large)
+            Text(viewModel.progressMessage)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+
+    /// Phase 2: Select target Agents and confirm import
+    /// Shows skill preview card + overwrite warning + Agent grid + Import button
+    private var selectAgentsPhase: some View {
+        VStack(spacing: 0) {
+            // Skill preview card (scrollable if content is tall)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    // Skill name and description preview
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(viewModel.skillMetadata?.name ?? viewModel.skillName)
+                            .font(.title3)
+                            .fontWeight(.semibold)
+
+                        if let desc = viewModel.skillMetadata?.description, !desc.isEmpty {
+                            Text(desc)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(3)
+                        }
+                    }
+
+                    // Source path display (shows where the skill is being imported from)
+                    if let dirURL = viewModel.selectedDirectoryURL {
+                        HStack(spacing: 4) {
+                            Image(systemName: "folder")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(dirURL.path)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                // lineLimit(1) + truncationMode(.middle) truncates long paths in the middle
+                                // e.g., "/Users/.../very-long-path/skill-dir" → shows start and end with ... in middle
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+
+                    // Overwrite warning: shown when a skill with the same name already exists
+                    if viewModel.alreadyExists {
+                        HStack(spacing: 6) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                            Text("A skill named \"\(viewModel.skillName)\" already exists and will be overwritten.")
+                                .font(.caption)
+                                .foregroundStyle(.orange)
+                        }
+                        .padding(8)
+                        .background(Color.orange.opacity(0.1))
+                        // clipShape rounds the corners of the background
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                    }
+                }
+                .padding()
+            }
+
+            Divider()
+
+            // Agent selection area + Import button
+            VStack(spacing: 12) {
+                // Agent selection grid (same layout as SkillInstallView)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Install to:")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    // LazyVGrid adapts column width, automatically wraps based on available space
+                    // adaptive(minimum: 120) means each column is at least 120pt
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), alignment: .leading)], alignment: .leading, spacing: 8) {
+                        ForEach(AgentType.allCases) { agentType in
+                            let isDetected = skillManager.agents.first { $0.type == agentType }?.isInstalled == true
+                            // Toggle is macOS checkbox component
+                            Toggle(isOn: Binding(
+                                get: { viewModel.selectedAgents.contains(agentType) },
+                                set: { _ in viewModel.toggleAgentSelection(agentType) }
+                            )) {
+                                Label(agentType.displayName, systemImage: agentType.iconName)
+                                    .font(.caption)
+                            }
+                            .toggleStyle(.checkbox)
+                            // Uninstalled Agents have reduced opacity but are still selectable
+                            .opacity(isDetected ? 1.0 : 0.5)
+                        }
+                    }
+                }
+
+                // Import button
+                HStack {
+                    Spacer()
+
+                    Button("Import") {
+                        Task { await viewModel.importSkill() }
+                    }
+                    .disabled(viewModel.selectedAgents.isEmpty)
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding()
+        }
+    }
+
+    /// Phase: Importing in progress (shows spinner)
+    private var importingPhase: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            ProgressView()
+                .controlSize(.large)
+            Text(viewModel.progressMessage)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+
+    /// Phase: Import completed (green checkmark + action buttons)
+    private var completedPhase: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.green)
+
+            Text("Import Complete")
+                .font(.headline)
+
+            Text("\"\(viewModel.skillName)\" has been imported successfully")
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                // "Import More" button: reset state and start over
+                Button("Import More") {
+                    viewModel.reset()
+                }
+
+                Button("Done") {
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+
+            Spacer()
+        }
+    }
+
+    /// Phase: Error (orange triangle + error message + retry button)
+    /// - Parameter message: Error message to display
+    private func errorPhase(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.orange)
+
+            Text("Something went wrong")
+                .font(.headline)
+
+            Text(message)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            Button("Try Again") {
+                viewModel.reset()
+            }
+
+            Spacer()
+        }
+    }
+}

--- a/Sources/SkillDeck/Views/Sidebar/SidebarView.swift
+++ b/Sources/SkillDeck/Views/Sidebar/SidebarView.swift
@@ -52,6 +52,10 @@ struct SidebarView: View {
     /// This way uses only one @State variable to control both sheet display and content, avoiding dual state synchronization timing issues
     @State private var installVM: SkillInstallViewModel?
 
+    /// Local import modal's ViewModel (created only when showing sheet)
+    /// Same pattern as installVM: nil = hidden, non-nil = show sheet
+    @State private var localImportVM: LocalImportViewModel?
+
     var body: some View {
         List(selection: $selection) {
             // Section creates groups (shown as collapsible groups in macOS sidebar)
@@ -132,14 +136,30 @@ struct SidebarView: View {
             }
 
             // F10: "+" button for installing new skill
-            // ToolbarItem defaults to toolbar trailing when placement is not specified
+            // Menu with primaryAction: clicking the button directly opens GitHub install,
+            // long-press or clicking the chevron reveals dropdown with both options.
+            // primaryAction makes the menu button behave as a split button (action + dropdown)
             ToolbarItem {
-                Button {
-                    installVM = SkillInstallViewModel(skillManager: skillManager)
+                Menu {
+                    // Dropdown menu items (shown on long-press or chevron click)
+                    Button {
+                        installVM = SkillInstallViewModel(skillManager: skillManager)
+                    } label: {
+                        Label("From GitHub...", systemImage: "globe")
+                    }
+
+                    Button {
+                        localImportVM = LocalImportViewModel(skillManager: skillManager)
+                    } label: {
+                        Label("From Local Folder...", systemImage: "folder")
+                    }
                 } label: {
                     Image(systemName: "plus")
+                } primaryAction: {
+                    // Default click action: open GitHub install (most common use case)
+                    installVM = SkillInstallViewModel(skillManager: skillManager)
                 }
-                .help("Install skill from GitHub")
+                .help("Install skill")
             }
 
             // F12: Batch check updates for all skills
@@ -197,6 +217,14 @@ struct SidebarView: View {
             SkillInstallView(viewModel: vm)
                 // .environment() injects SkillManager into sheet's view tree
                 // Sheet creates new view hierarchy, needs to re-inject environment dependencies
+                .environment(skillManager)
+        }
+        // Local import sheet modal
+        // Same pattern as install sheet: .sheet(item:) binds display to Optional variable
+        .sheet(item: $localImportVM, onDismiss: {
+            localImportVM = nil
+        }) { vm in
+            LocalImportView(viewModel: vm)
                 .environment(skillManager)
         }
     }

--- a/Tests/SkillDeckTests/LocalImportTests.swift
+++ b/Tests/SkillDeckTests/LocalImportTests.swift
@@ -1,0 +1,292 @@
+import XCTest
+@testable import SkillDeck
+
+/// Unit tests for local skill import functionality
+///
+/// Tests the importLocalSkill() method on SkillManager and related validation logic.
+/// Uses temporary directories to simulate skill directories with SKILL.md files.
+///
+/// XCTest is Swift's testing framework (similar to JUnit / Go's testing package):
+/// - Test classes inherit from XCTestCase
+/// - Test methods start with "test"
+/// - Use XCTAssert* assertion methods (similar to JUnit's Assert.*)
+/// - Run via: swift test --filter LocalImportTests
+final class LocalImportTests: XCTestCase {
+
+    /// Temporary directory for test fixtures (created fresh for each test)
+    var tempDir: URL!
+
+    /// Temporary directory simulating ~/.agents/ (for lock file and canonical skills)
+    var agentsDir: URL!
+
+    /// LockFileManager pointed at test lock file (avoids touching real ~/.agents/.skill-lock.json)
+    var lockFileManager: LockFileManager!
+
+    // MARK: - Setup / Teardown
+
+    /// setUp runs before each test method (similar to JUnit's @Before)
+    /// Creates temp directories and a LockFileManager pointed at test paths
+    override func setUp() async throws {
+        // Create unique temp directory per test to avoid interference between tests
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SkillDeckLocalImportTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        // Create agents directory (simulates ~/.agents/)
+        agentsDir = tempDir.appendingPathComponent("agents")
+        try FileManager.default.createDirectory(
+            at: agentsDir.appendingPathComponent("skills"),
+            withIntermediateDirectories: true
+        )
+
+        // Create LockFileManager pointed at test path
+        let lockFilePath = agentsDir.appendingPathComponent(".skill-lock.json")
+        lockFileManager = LockFileManager(filePath: lockFilePath)
+
+        // Create empty lock file so updateEntry can work
+        try await lockFileManager.createIfNotExists()
+    }
+
+    /// tearDown runs after each test method (similar to JUnit's @After)
+    /// Cleans up temp directories
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        agentsDir = nil
+        lockFileManager = nil
+    }
+
+    // MARK: - Helper Methods
+
+    /// Create a test skill directory with a valid SKILL.md file
+    /// - Parameters:
+    ///   - name: Directory name (becomes the skill name)
+    ///   - skillName: Name field in YAML frontmatter (defaults to directory name)
+    ///   - description: Description field in YAML frontmatter
+    /// - Returns: URL of the created skill directory
+    private func createValidSkillDir(
+        name: String,
+        skillName: String? = nil,
+        description: String = "A test skill"
+    ) throws -> URL {
+        let skillDir = tempDir.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: skillDir, withIntermediateDirectories: true)
+
+        // Write a valid SKILL.md with YAML frontmatter + markdown body
+        let content = """
+        ---
+        name: \(skillName ?? name)
+        description: \(description)
+        ---
+
+        # \(skillName ?? name)
+
+        This is a test skill.
+        """
+        let skillMDURL = skillDir.appendingPathComponent("SKILL.md")
+        try content.write(to: skillMDURL, atomically: true, encoding: .utf8)
+
+        return skillDir
+    }
+
+    // MARK: - Validation Tests
+
+    /// Test that a valid SKILL.md can be parsed from a local directory
+    func testValidSkillMDParseable() throws {
+        // Create a directory with valid SKILL.md
+        let skillDir = try createValidSkillDir(name: "test-skill", description: "My test skill")
+        let skillMDURL = skillDir.appendingPathComponent("SKILL.md")
+
+        // Parse and verify
+        let result = try SkillMDParser.parse(fileURL: skillMDURL)
+        XCTAssertEqual(result.metadata.name, "test-skill")
+        XCTAssertEqual(result.metadata.description, "My test skill")
+        XCTAssertTrue(result.markdownBody.contains("# test-skill"))
+    }
+
+    /// Test that a directory without SKILL.md is detected
+    func testMissingSkillMD() throws {
+        // Create an empty directory (no SKILL.md)
+        let emptyDir = tempDir.appendingPathComponent("empty-skill")
+        try FileManager.default.createDirectory(at: emptyDir, withIntermediateDirectories: true)
+
+        // Verify SKILL.md does not exist
+        let skillMDURL = emptyDir.appendingPathComponent("SKILL.md")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: skillMDURL.path))
+    }
+
+    /// Test that invalid SKILL.md content triggers a parse error
+    func testInvalidSkillMDContent() throws {
+        // Create a directory with invalid SKILL.md (no YAML frontmatter)
+        let skillDir = tempDir.appendingPathComponent("bad-skill")
+        try FileManager.default.createDirectory(at: skillDir, withIntermediateDirectories: true)
+
+        let invalidContent = "This is not valid SKILL.md - no YAML frontmatter"
+        let skillMDURL = skillDir.appendingPathComponent("SKILL.md")
+        try invalidContent.write(to: skillMDURL, atomically: true, encoding: .utf8)
+
+        // Parsing should throw an error (no --- delimiters for YAML frontmatter)
+        XCTAssertThrowsError(try SkillMDParser.parse(fileURL: skillMDURL)) { error in
+            // Verify it's a ParseError (not some other unexpected error)
+            XCTAssertTrue(error is SkillMDParser.ParseError,
+                         "Expected ParseError but got \(type(of: error))")
+        }
+    }
+
+    /// Test that selecting a SKILL.md file URL resolves to its parent directory
+    /// This tests the logic in LocalImportViewModel.openFolderPicker()
+    func testSkillMDFileResolvesToParentDirectory() throws {
+        let skillDir = try createValidSkillDir(name: "resolve-test")
+        let skillMDURL = skillDir.appendingPathComponent("SKILL.md")
+
+        // Simulate what LocalImportViewModel does: if URL points to SKILL.md, use parent
+        let resolvedURL: URL
+        if skillMDURL.lastPathComponent == "SKILL.md" {
+            resolvedURL = skillMDURL.deletingLastPathComponent()
+        } else {
+            resolvedURL = skillMDURL
+        }
+
+        // The resolved URL should be the skill directory, not the SKILL.md file
+        XCTAssertEqual(
+            resolvedURL.standardized.path,
+            skillDir.standardized.path,
+            "SKILL.md URL should resolve to parent directory"
+        )
+    }
+
+    // MARK: - File Copy Tests
+
+    /// Test that copying a skill directory preserves all files
+    func testCopySkillDirectoryPreservesFiles() throws {
+        // Create a skill directory with SKILL.md + extra files
+        let sourceDir = try createValidSkillDir(name: "copy-test")
+
+        // Add an extra file to verify copy preserves all contents
+        let extraFile = sourceDir.appendingPathComponent("extra.txt")
+        try "extra content".write(to: extraFile, atomically: true, encoding: .utf8)
+
+        // Copy to canonical location
+        let canonicalDir = agentsDir.appendingPathComponent("skills").appendingPathComponent("copy-test")
+        try FileManager.default.copyItem(at: sourceDir, to: canonicalDir)
+
+        // Verify all files were copied
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: canonicalDir.appendingPathComponent("SKILL.md").path
+        ))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: canonicalDir.appendingPathComponent("extra.txt").path
+        ))
+
+        // Verify SKILL.md content is preserved
+        let copiedContent = try String(contentsOf: canonicalDir.appendingPathComponent("SKILL.md"), encoding: .utf8)
+        XCTAssertTrue(copiedContent.contains("copy-test"))
+    }
+
+    /// Test that overwriting an existing skill directory works correctly
+    func testOverwriteExistingSkillDirectory() throws {
+        let fm = FileManager.default
+        let canonicalDir = agentsDir.appendingPathComponent("skills").appendingPathComponent("overwrite-test")
+
+        // First import: create initial version
+        let sourceV1 = try createValidSkillDir(name: "overwrite-v1", skillName: "overwrite-test", description: "Version 1")
+        try fm.copyItem(at: sourceV1, to: canonicalDir)
+
+        // Verify V1 exists
+        let v1Content = try String(contentsOf: canonicalDir.appendingPathComponent("SKILL.md"), encoding: .utf8)
+        XCTAssertTrue(v1Content.contains("Version 1"))
+
+        // Second import: overwrite with V2 (delete first, then copy — same as importLocalSkill)
+        let sourceV2 = try createValidSkillDir(name: "overwrite-v2", skillName: "overwrite-test", description: "Version 2")
+        if fm.fileExists(atPath: canonicalDir.path) {
+            try fm.removeItem(at: canonicalDir)
+        }
+        try fm.copyItem(at: sourceV2, to: canonicalDir)
+
+        // Verify V2 replaced V1
+        let v2Content = try String(contentsOf: canonicalDir.appendingPathComponent("SKILL.md"), encoding: .utf8)
+        XCTAssertTrue(v2Content.contains("Version 2"))
+        XCTAssertFalse(v2Content.contains("Version 1"))
+    }
+
+    // MARK: - Lock File Tests
+
+    /// Test that lock entry is created with correct fields for local import
+    func testLockEntryFieldsForLocalImport() async throws {
+        let sourceDir = try createValidSkillDir(name: "lock-test-skill")
+
+        // Simulate what importLocalSkill does: create lock entry with sourceType "local"
+        let now = ISO8601DateFormatter().string(from: Date())
+        let entry = LockEntry(
+            source: sourceDir.path,
+            sourceType: "local",
+            sourceUrl: sourceDir.path,
+            skillPath: "lock-test-skill/SKILL.md",
+            skillFolderHash: "",  // Local imports have no git hash
+            installedAt: now,
+            updatedAt: now
+        )
+        try await lockFileManager.updateEntry(skillName: "lock-test-skill", entry: entry)
+
+        // Read back and verify
+        let readEntry = try await lockFileManager.getEntry(skillName: "lock-test-skill")
+        XCTAssertNotNil(readEntry, "Lock entry should exist after import")
+        XCTAssertEqual(readEntry?.sourceType, "local", "sourceType should be 'local' for local imports")
+        XCTAssertEqual(readEntry?.source, sourceDir.path, "source should be the original directory path")
+        XCTAssertEqual(readEntry?.sourceUrl, sourceDir.path, "sourceUrl should be the original directory path")
+        XCTAssertEqual(readEntry?.skillPath, "lock-test-skill/SKILL.md")
+        XCTAssertEqual(readEntry?.skillFolderHash, "", "skillFolderHash should be empty for local imports")
+    }
+
+    /// Test that local skills are filtered out in checkAllUpdates filter logic
+    /// This verifies the filtering condition: sourceType != "local"
+    func testLocalSkillsSkippedInUpdateCheck() {
+        // Create lock entries for both types
+        let githubEntry = LockEntry(
+            source: "owner/repo",
+            sourceType: "github",
+            sourceUrl: "https://github.com/owner/repo.git",
+            skillPath: "skills/test/SKILL.md",
+            skillFolderHash: "abc123",
+            installedAt: "2024-01-01T00:00:00Z",
+            updatedAt: "2024-01-01T00:00:00Z"
+        )
+
+        let localEntry = LockEntry(
+            source: "/Users/test/my-skill",
+            sourceType: "local",
+            sourceUrl: "/Users/test/my-skill",
+            skillPath: "my-skill/SKILL.md",
+            skillFolderHash: "",
+            installedAt: "2024-01-01T00:00:00Z",
+            updatedAt: "2024-01-01T00:00:00Z"
+        )
+
+        // Simulate the filter logic from checkAllUpdates()
+        // This is the exact condition used in SkillManager.checkAllUpdates():
+        // skills.filter { $0.lockEntry != nil && $0.lockEntry?.sourceType != "local" }
+        let entries: [LockEntry?] = [githubEntry, localEntry, nil]
+        let filtered = entries.filter { $0 != nil && $0?.sourceType != "local" }
+
+        // Only the GitHub entry should pass the filter
+        XCTAssertEqual(filtered.count, 1, "Only non-local entries should pass the filter")
+        XCTAssertEqual(filtered.first??.sourceType, "github")
+    }
+
+    // MARK: - ImportError Tests
+
+    /// Test ImportError enum descriptions are human-readable
+    func testImportErrorDescriptions() {
+        let dirNotFound = SkillManager.ImportError.directoryNotFound("/some/path")
+        XCTAssertTrue(dirNotFound.localizedDescription.contains("/some/path"),
+                      "Error message should contain the path")
+
+        let noSkillMD = SkillManager.ImportError.skillMDNotFound("/another/path")
+        XCTAssertTrue(noSkillMD.localizedDescription.contains("SKILL.md"),
+                      "Error message should mention SKILL.md")
+
+        let parseFailed = SkillManager.ImportError.parseFailed("invalid YAML")
+        XCTAssertTrue(parseFailed.localizedDescription.contains("invalid YAML"),
+                      "Error message should contain the parse error detail")
+    }
+}

--- a/Tests/SkillDeckTests/SkillMDParserTests.swift
+++ b/Tests/SkillDeckTests/SkillMDParserTests.swift
@@ -132,6 +132,28 @@ final class SkillMDParserTests: XCTestCase {
         XCTAssertTrue(result.contains("World"))
     }
 
+    // MARK: - Edge Case Tests
+
+    /// Test parsing description with colons (common in real-world SKILL.md files)
+    /// YAML spec: ": " inside a plain scalar value should be valid in block context,
+    /// but some parsers may interpret it as a nested mapping key
+    func testParseDescriptionWithColons() throws {
+        let content = """
+        ---
+        name: ai-radar
+        description: Run daily AI news aggregation: fetch data -> analyze -> generate report
+        allowed-tools: Bash, Read, Write, Glob
+        ---
+
+        # AI-Radar
+        """
+
+        let result = try SkillMDParser.parse(content: content)
+        XCTAssertEqual(result.metadata.name, "ai-radar")
+        XCTAssertTrue(result.metadata.description.contains("aggregation"))
+        XCTAssertEqual(result.metadata.allowedTools, "Bash, Read, Write, Glob")
+    }
+
     // MARK: - 往返测试（Round-trip）
 
     /// 测试：解析 → 序列化 → 再解析，数据应该一致


### PR DESCRIPTION
Closes #21

## Summary

- Add "From Local Folder..." option to the "+" toolbar menu, allowing users to import skills from local directories via NSOpenPanel
- Add `importLocalSkill()` to SkillManager with full validation, file copy, symlink creation, and lock file update (sourceType: "local")
- Add fallback YAML parser in SkillMDParser for SKILL.md files where description contains colons (`: `) that break Yams strict decoder
- Skip local-imported skills in `checkAllUpdates()` since they have no remote repository to compare against
- Enable `showsHiddenFiles` on NSOpenPanel so users can navigate into `.claude/skills/` and similar hidden directories

## Manual Verification Required

- Launch app → click "+" dropdown chevron → "From Local Folder..." → select a directory with SKILL.md → verify skill appears in dashboard
- Select a SKILL.md file (not directory) → verify it resolves to parent directory and imports correctly
- Select an invalid directory (no SKILL.md) → verify clear error message
- Import a skill with colons in SKILL.md description → verify it parses without error
- Check `~/.agents/.skill-lock.json` → verify local skill entry has `sourceType: "local"`
- Verify hidden directories (e.g., `~/.claude/skills/`) are visible in the folder picker

## Regression Checklist

- [ ] Existing GitHub install flow ("From GitHub..." / direct "+" click) still works
- [ ] Existing SKILL.md parsing (standard format, with allowed-tools, minimal fields) not broken
- [ ] Batch update check skips local skills without errors
- [ ] Skill deletion, editing, and agent assignment still work for both GitHub and local skills
- [ ] Sidebar badge counts and agent filtering remain correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)