### PR TITLE
feat: add ClawHub marketplace support for OpenClaw

### DIFF
--- a/Sources/SkillDeck/Models/ClawHubSkill.swift
+++ b/Sources/SkillDeck/Models/ClawHubSkill.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// ClawHubSkill models a single skill returned by the ClawHub HTTP API.
+///
+/// Unlike `RegistrySkill`, which is tightly coupled to skills.sh / GitHub repository semantics,
+/// this model captures ClawHub-native concepts such as slug, marketplace stats, owner profile,
+/// and the latest published version.
+///
+/// We intentionally keep this model UI-friendly:
+/// - String fields are already normalized for display.
+/// - Browser URLs are derived here so Views don't hard-code marketplace URL rules.
+/// - Formatted helpers live alongside the raw values, similar to a small view model.
+struct ClawHubSkill: Identifiable, Hashable {
+
+    /// Stable marketplace slug used by ClawHub APIs and browser URLs.
+    let slug: String
+
+    /// Human-readable skill name.
+    /// ClawHub calls this `displayName`; we store it separately from `slug` because the name can
+    /// contain spaces and title casing while the slug is filesystem-safe.
+    let displayName: String
+
+    /// Short summary shown in list rows and headers.
+    let summary: String
+
+    /// Latest published version string if the API exposed one.
+    let latestVersion: String?
+
+    /// Download count from marketplace stats.
+    let downloads: Int
+
+    /// Star count from marketplace stats.
+    let stars: Int
+
+    /// Number of published versions, if the API provided it.
+    let versionCount: Int?
+
+    /// ClawHub owner handle (for example `ShawnPana`).
+    let ownerHandle: String?
+
+    /// Optional owner display name for richer detail UI.
+    let ownerDisplayName: String?
+
+    /// Unix timestamp in milliseconds from the API.
+    let updatedAtMilliseconds: Int64?
+
+    /// `Identifiable` conformance lets SwiftUI Lists track each item with stable identity.
+    /// The slug is globally unique inside ClawHub, so it is the natural identity key.
+    var id: String { slug }
+
+    /// Preferred display name, with slug fallback for incomplete API payloads.
+    var name: String {
+        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? slug : trimmed
+    }
+
+    /// User-facing description text with a sensible empty fallback.
+    var descriptionText: String {
+        let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "No description provided." : trimmed
+    }
+
+    /// Public browser URL for the marketplace detail page.
+    ///
+    /// This matches the actual ClawHub route pattern discovered from the site metadata:
+    /// `https://clawhub.ai/skills/<slug>`.
+    var browserURL: URL {
+        URL(string: "https://clawhub.ai/skills/\(slug)")!
+    }
+
+    /// Formatted download count for compact UI labels.
+    var formattedDownloads: String {
+        Self.numberFormatter.string(from: NSNumber(value: downloads)) ?? "\(downloads)"
+    }
+
+    /// Formatted star count for compact UI labels.
+    var formattedStars: String {
+        Self.numberFormatter.string(from: NSNumber(value: stars)) ?? "\(stars)"
+    }
+
+    /// Human-readable date for the last marketplace update.
+    var formattedUpdatedDate: String? {
+        guard let updatedAtMilliseconds else { return nil }
+        let date = Date(timeIntervalSince1970: TimeInterval(updatedAtMilliseconds) / 1000)
+        return date.formatted(date: .abbreviated, time: .omitted)
+    }
+
+    private static let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
+}
+
+/// ClawHubSkillDetail contains additional metadata only available from the detail endpoint.
+///
+/// Keeping this separate avoids forcing every list/search response to fake data it doesn't contain.
+struct ClawHubSkillDetail: Hashable {
+    let skill: ClawHubSkill
+    let latestVersion: String?
+    let latestVersionCreatedAt: Int64?
+    let latestChangelog: String?
+    let license: String?
+    let moderationVerdict: String?
+    let moderationSummary: String?
+
+    /// Version string to prefer for installation actions.
+    ///
+    /// We check the detail payload first because it is the most authoritative source.
+    var installVersion: String? {
+        latestVersion ?? skill.latestVersion
+    }
+
+    /// Human-readable publish date for the latest version.
+    var formattedLatestVersionDate: String? {
+        guard let latestVersionCreatedAt else { return nil }
+        let date = Date(timeIntervalSince1970: TimeInterval(latestVersionCreatedAt) / 1000)
+        return date.formatted(date: .abbreviated, time: .omitted)
+    }
+}

--- a/Sources/SkillDeck/Services/ClawHubService.swift
+++ b/Sources/SkillDeck/Services/ClawHubService.swift
@@ -1,0 +1,370 @@
+import Foundation
+
+/// ClawHubService talks to ClawHub's public HTTP API.
+///
+/// We model this as an `actor` because networking, response parsing, and the small in-memory caches
+/// are all shared mutable state. `actor` gives us data-race safety without manual locking.
+actor ClawHubService {
+
+    /// Sort fields supported by ClawHub's `/skills` listing page.
+    ///
+    /// We keep a `.default` case so SkillDeck can preserve ClawHub's server-side default ordering
+    /// when the user has not explicitly picked a sort yet.
+    enum SkillSort: String, CaseIterable, Identifiable {
+        case `default`
+        case downloads
+        case stars
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .default:
+                return "Default"
+            case .downloads:
+                return "Downloads"
+            case .stars:
+                return "Stars"
+            }
+        }
+    }
+
+    /// Direction values accepted by ClawHub when a sort field is present.
+    enum SortDirection: String, CaseIterable, Identifiable {
+        case descending = "desc"
+        case ascending = "asc"
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .descending:
+                return "Desc"
+            case .ascending:
+                return "Asc"
+            }
+        }
+    }
+
+    /// Query options for the featured ClawHub list.
+    ///
+    /// The search endpoint uses a different API shape, so these options only apply to the browse
+    /// list shown when the user is not actively searching.
+    struct BrowseOptions: Equatable {
+        var sort: SkillSort = .default
+        var direction: SortDirection = .descending
+        var highlightedOnly = false
+        var nonSuspiciousOnly = false
+        var limit = 50
+
+        var queryItems: [URLQueryItem] {
+            var items = [URLQueryItem(name: "limit", value: "\(limit)")]
+
+            if sort != .default {
+                items.append(URLQueryItem(name: "sort", value: sort.rawValue))
+                items.append(URLQueryItem(name: "dir", value: direction.rawValue))
+            }
+
+            if highlightedOnly {
+                items.append(URLQueryItem(name: "highlighted", value: "true"))
+            }
+
+            if nonSuspiciousOnly {
+                items.append(URLQueryItem(name: "nonSuspicious", value: "true"))
+            }
+
+            return items
+        }
+    }
+
+    /// User-visible service errors.
+    ///
+    /// Using LocalizedError lets ViewModels surface human-readable messages directly in alerts and
+    /// empty states instead of exposing raw HTTP status codes everywhere.
+    enum ServiceError: Error, LocalizedError {
+        case invalidURL
+        case invalidResponse(statusCode: Int, message: String)
+        case rateLimited(retryAfterSeconds: Int?)
+        case archiveUnavailable
+        case emptySkillContent
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "Failed to build a valid ClawHub request URL."
+            case .invalidResponse(let statusCode, let message):
+                if message.isEmpty {
+                    return "ClawHub request failed with status code \(statusCode)."
+                }
+                return "ClawHub request failed (\(statusCode)): \(message)"
+            case .rateLimited(let retryAfterSeconds):
+                if let retryAfterSeconds {
+                    return "ClawHub is temporarily rate limiting requests. Try again in about \(retryAfterSeconds) seconds."
+                }
+                return "ClawHub is temporarily rate limiting requests. Please try again later."
+            case .archiveUnavailable:
+                return "ClawHub did not return a downloadable skill archive."
+            case .emptySkillContent:
+                return "ClawHub returned an empty SKILL.md file."
+            }
+        }
+    }
+
+    private let baseURL = URL(string: "https://clawhub.ai")!
+    private let session: URLSession
+
+    /// Small response caches reduce repeated requests when a user clicks the same skill multiple
+    /// times, which also helps avoid ClawHub's fairly aggressive rate limits.
+    private var detailCache: [String: ClawHubSkillDetail] = [:]
+    private var contentCache: [String: String] = [:]
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    // MARK: - Public API
+
+    /// Load a page of ClawHub skills for the browse view.
+    func fetchSkills(options: BrowseOptions = BrowseOptions()) async throws -> [ClawHubSkill] {
+        let response: SkillListResponse = try await sendJSONRequest(
+            path: "/api/v1/skills",
+            queryItems: options.queryItems
+        )
+        return response.items.map { $0.toClawHubSkill(owner: nil) }
+    }
+
+    /// Search ClawHub skills by free-text query.
+    func searchSkills(query: String, limit: Int = 50) async throws -> [ClawHubSkill] {
+        let response: SkillSearchResponse = try await sendJSONRequest(
+            path: "/api/v1/search",
+            queryItems: [
+                URLQueryItem(name: "q", value: query),
+                URLQueryItem(name: "limit", value: "\(limit)")
+            ]
+        )
+        return response.results.map { $0.toClawHubSkill() }
+    }
+
+    /// Load the richer detail payload for one selected skill.
+    func fetchSkillDetail(slug: String) async throws -> ClawHubSkillDetail {
+        if let cached = detailCache[slug] {
+            return cached
+        }
+
+        let response: SkillDetailResponse = try await sendJSONRequest(path: "/api/v1/skills/\(slug)")
+        let detail = response.toClawHubSkillDetail()
+        detailCache[slug] = detail
+        return detail
+    }
+
+    /// Download the raw `SKILL.md` file used for detail rendering and markdown-only fallback installs.
+    func fetchSkillContent(slug: String) async throws -> String {
+        if let cached = contentCache[slug] {
+            return cached
+        }
+
+        let data = try await sendDataRequest(
+            path: "/api/v1/skills/\(slug)/file",
+            queryItems: [URLQueryItem(name: "path", value: "SKILL.md")]
+        )
+
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw ServiceError.invalidResponse(statusCode: 200, message: "ClawHub returned non-UTF8 SKILL.md content.")
+        }
+
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ServiceError.emptySkillContent
+        }
+
+        contentCache[slug] = content
+        return content
+    }
+
+    /// Download the published archive for a specific skill version.
+    ///
+    /// The caller can choose to fall back to a markdown-only install when this request is rate
+    /// limited, so we return raw `Data` instead of writing files directly here.
+    func downloadSkillArchive(slug: String, version: String) async throws -> Data {
+        let data = try await sendDataRequest(
+            path: "/api/v1/download",
+            queryItems: [
+                URLQueryItem(name: "slug", value: slug),
+                URLQueryItem(name: "version", value: version)
+            ]
+        )
+
+        guard !data.isEmpty else {
+            throw ServiceError.archiveUnavailable
+        }
+
+        return data
+    }
+
+    // MARK: - Request helpers
+
+    /// Decode a JSON API response into a Codable DTO.
+    private func sendJSONRequest<Response: Decodable>(
+        path: String,
+        queryItems: [URLQueryItem] = []
+    ) async throws -> Response {
+        let data = try await sendDataRequest(path: path, queryItems: queryItems)
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+
+    /// Perform a request and validate the HTTP response.
+    private func sendDataRequest(
+        path: String,
+        queryItems: [URLQueryItem] = []
+    ) async throws -> Data {
+        let request = try makeRequest(path: path, queryItems: queryItems)
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data)
+        return data
+    }
+
+    /// Build a GET request with the headers ClawHub expects for a browser-like client.
+    private func makeRequest(path: String, queryItems: [URLQueryItem]) throws -> URLRequest {
+        guard var components = URLComponents(url: baseURL.appendingPathComponent(path), resolvingAgainstBaseURL: false) else {
+            throw ServiceError.invalidURL
+        }
+
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+
+        guard let url = components.url else {
+            throw ServiceError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+        request.setValue("SkillDeck", forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
+    /// Centralized HTTP validation keeps status-code handling consistent across endpoints.
+    private func validate(response: URLResponse, data: Data) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ServiceError.invalidResponse(statusCode: -1, message: "ClawHub returned a non-HTTP response.")
+        }
+
+        if httpResponse.statusCode == 429 {
+            let retryAfter = httpResponse.value(forHTTPHeaderField: "retry-after").flatMap(Int.init)
+            throw ServiceError.rateLimited(retryAfterSeconds: retryAfter)
+        }
+
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let message = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            throw ServiceError.invalidResponse(statusCode: httpResponse.statusCode, message: message)
+        }
+    }
+}
+
+// MARK: - DTOs
+
+/// DTOs stay private to the service because they match the API shape, not the app's domain model.
+private extension ClawHubService {
+    struct SkillListResponse: Decodable {
+        let items: [SkillSummaryDTO]
+    }
+
+    struct SkillSearchResponse: Decodable {
+        let results: [SearchResultDTO]
+    }
+
+    struct SkillDetailResponse: Decodable {
+        let skill: SkillSummaryDTO
+        let latestVersion: VersionDTO?
+        let owner: OwnerDTO?
+        let moderation: ModerationDTO?
+
+        func toClawHubSkillDetail() -> ClawHubSkillDetail {
+            let skillModel = skill.toClawHubSkill(owner: owner)
+            return ClawHubSkillDetail(
+                skill: skillModel,
+                latestVersion: latestVersion?.version ?? skillModel.latestVersion,
+                latestVersionCreatedAt: latestVersion?.createdAt,
+                latestChangelog: latestVersion?.changelog,
+                license: latestVersion?.license,
+                moderationVerdict: moderation?.verdict,
+                moderationSummary: moderation?.summary
+            )
+        }
+    }
+
+    struct SkillSummaryDTO: Decodable {
+        let slug: String
+        let displayName: String?
+        let summary: String?
+        let stats: StatsDTO?
+        let updatedAt: Int64?
+        let latestVersion: VersionDTO?
+        let tags: TagsDTO?
+
+        func toClawHubSkill(owner: OwnerDTO?) -> ClawHubSkill {
+            ClawHubSkill(
+                slug: slug,
+                displayName: displayName ?? slug,
+                summary: summary ?? "",
+                latestVersion: latestVersion?.version ?? tags?.latest,
+                downloads: stats?.downloads ?? 0,
+                stars: stats?.stars ?? 0,
+                versionCount: stats?.versions,
+                ownerHandle: owner?.handle,
+                ownerDisplayName: owner?.displayName,
+                updatedAtMilliseconds: updatedAt
+            )
+        }
+    }
+
+    struct SearchResultDTO: Decodable {
+        let slug: String
+        let displayName: String?
+        let summary: String?
+        let version: String?
+        let updatedAt: Int64?
+
+        func toClawHubSkill() -> ClawHubSkill {
+            ClawHubSkill(
+                slug: slug,
+                displayName: displayName ?? slug,
+                summary: summary ?? "",
+                latestVersion: version,
+                downloads: 0,
+                stars: 0,
+                versionCount: nil,
+                ownerHandle: nil,
+                ownerDisplayName: nil,
+                updatedAtMilliseconds: updatedAt
+            )
+        }
+    }
+
+    struct StatsDTO: Decodable {
+        let downloads: Int?
+        let stars: Int?
+        let versions: Int?
+    }
+
+    struct TagsDTO: Decodable {
+        let latest: String?
+    }
+
+    struct VersionDTO: Decodable {
+        let version: String?
+        let createdAt: Int64?
+        let changelog: String?
+        let license: String?
+    }
+
+    struct OwnerDTO: Decodable {
+        let handle: String?
+        let displayName: String?
+    }
+
+    struct ModerationDTO: Decodable {
+        let verdict: String?
+        let summary: String?
+    }
+}

--- a/Sources/SkillDeck/Services/SkillManager.swift
+++ b/Sources/SkillDeck/Services/SkillManager.swift
@@ -59,6 +59,16 @@ final class SkillManager {
         }
     }
 
+    /// Result for ClawHub installations.
+    ///
+    /// ClawHub normally provides a full zip bundle, but the API can occasionally rate-limit or fail.
+    /// In that case we still allow a markdown-only fallback so OpenClaw can at least load the main
+    /// `SKILL.md`, while the UI clearly tells the user that auxiliary files were not installed.
+    enum ClawHubInstallResult: Equatable {
+        case installedFromArchive
+        case installedSkillMarkdownOnly
+    }
+
     // MARK: - Published State (UI-bound state)
 
     /// All discovered skills (deduplicated)
@@ -319,8 +329,6 @@ final class SkillManager {
         repoURL: String,
         targetAgents: Set<AgentType>
     ) async throws {
-        let fm = FileManager.default
-
         // 1. Get tree hash (git rev-parse HEAD:<folderPath>)
         let treeHash = try await gitService.getTreeHash(for: skill.folderPath, in: repoDir)
 
@@ -330,33 +338,7 @@ final class SkillManager {
         await commitHashCache.setHash(for: skill.id, hash: commitHash)
         try await commitHashCache.save()
 
-        // 2. Copy to canonical directory
-        // canonical path: ~/.agents/skills/<skillName>/
-        let canonicalDir = SkillScanner.sharedSkillsURL.appendingPathComponent(skill.id)
         let sourceDir = repoDir.appendingPathComponent(skill.folderPath)
-
-        // If already exists, delete first then copy (overwrite installation)
-        if fm.fileExists(atPath: canonicalDir.path) {
-            try fm.removeItem(at: canonicalDir)
-        }
-
-        // Ensure parent directory exists
-        if !fm.fileExists(atPath: SkillScanner.sharedSkillsURL.path) {
-            try fm.createDirectory(at: SkillScanner.sharedSkillsURL, withIntermediateDirectories: true)
-        }
-
-        // copyItem is like cp -r, recursively copies entire directory
-        try fm.copyItem(at: sourceDir, to: canonicalDir)
-
-        // 3. Create symlinks for selected Agents
-        for agent in targetAgents {
-            // Use try? to ignore existing symlink errors (idempotent operation)
-            try? SymlinkManager.createSymlink(from: canonicalDir, to: agent)
-        }
-
-        // 4. Update lock file
-        // Ensure lock file exists (may not exist on first installation)
-        try await lockFileManager.createIfNotExists()
 
         // ISO 8601 timestamp (consistent with npx skills CLI format)
         let now = ISO8601DateFormatter().string(from: Date())
@@ -369,10 +351,12 @@ final class SkillManager {
             installedAt: now,
             updatedAt: now
         )
-        try await lockFileManager.updateEntry(skillName: skill.id, entry: entry)
-
-        // 5. Refresh UI
-        await refresh()
+        try await persistInstalledSkillDirectory(
+            from: sourceDir,
+            skillName: skill.id,
+            targetAgents: targetAgents,
+            lockEntry: entry
+        )
     }
 
     // MARK: - Local Import
@@ -421,32 +405,6 @@ final class SkillManager {
             throw ImportError.parseFailed(error.localizedDescription)
         }
 
-        // 3. Copy directory to canonical path (~/.agents/skills/<skillName>/)
-        let canonicalDir = SkillScanner.sharedSkillsURL.appendingPathComponent(skillName)
-
-        // If already exists, delete first then copy (overwrite import)
-        if fm.fileExists(atPath: canonicalDir.path) {
-            try fm.removeItem(at: canonicalDir)
-        }
-
-        // Ensure parent directory (~/.agents/skills/) exists
-        if !fm.fileExists(atPath: SkillScanner.sharedSkillsURL.path) {
-            try fm.createDirectory(at: SkillScanner.sharedSkillsURL, withIntermediateDirectories: true)
-        }
-
-        // copyItem is like cp -r, recursively copies entire directory
-        try fm.copyItem(at: sourceURL, to: canonicalDir)
-
-        // 4. Create symlinks for selected Agents
-        for agent in targetAgents {
-            // Use try? to ignore existing symlink errors (idempotent operation)
-            try? SymlinkManager.createSymlink(from: canonicalDir, to: agent)
-        }
-
-        // 5. Update lock file with sourceType "local"
-        // Ensure lock file exists (may not exist on first import)
-        try await lockFileManager.createIfNotExists()
-
         // ISO 8601 timestamp (consistent with npx skills CLI format)
         let now = ISO8601DateFormatter().string(from: Date())
         let entry = LockEntry(
@@ -458,10 +416,89 @@ final class SkillManager {
             installedAt: now,
             updatedAt: now
         )
-        try await lockFileManager.updateEntry(skillName: skillName, entry: entry)
+        try await persistInstalledSkillDirectory(
+            from: sourceURL,
+            skillName: skillName,
+            targetAgents: targetAgents,
+            lockEntry: entry
+        )
+    }
 
-        // 6. Refresh UI
-        await refresh()
+    /// Install a skill fetched from ClawHub into the canonical directory, then expose it to OpenClaw.
+    ///
+    /// We intentionally do not shell out to `clawhub install`. SkillDeck keeps its own canonical
+    /// storage model (`~/.agents/skills`) and only creates the OpenClaw symlink after the files are
+    /// safely persisted locally. This keeps installation behavior consistent with the rest of the app.
+    func installClawHubSkill(
+        slug: String,
+        version: String,
+        detailPageURL: String,
+        skillContent: String?,
+        archiveData: Data?,
+        targetAgents: Set<AgentType>
+    ) async throws -> ClawHubInstallResult {
+        let fm = FileManager.default
+        let tempRoot = fm.temporaryDirectory.appendingPathComponent("SkillDeck-ClawHub-\(UUID().uuidString)")
+        try fm.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempRoot) }
+
+        let now = ISO8601DateFormatter().string(from: Date())
+        let entry = LockEntry(
+            source: slug,
+            sourceType: "clawhub",
+            sourceUrl: detailPageURL,
+            skillPath: "\(slug)/SKILL.md",
+            skillFolderHash: "",
+            installedAt: now,
+            updatedAt: now
+        )
+
+        if let archiveData {
+            let archiveURL = tempRoot.appendingPathComponent("\(slug).zip")
+            let extractedRoot = tempRoot.appendingPathComponent("extracted")
+            try archiveData.write(to: archiveURL)
+            try fm.createDirectory(at: extractedRoot, withIntermediateDirectories: true)
+
+            do {
+                try extractZipArchive(at: archiveURL, to: extractedRoot)
+                if let extractedSkillDir = try locateSkillDirectory(in: extractedRoot) {
+                    try await persistInstalledSkillDirectory(
+                        from: extractedSkillDir,
+                        skillName: slug,
+                        targetAgents: targetAgents,
+                        lockEntry: entry
+                    )
+                    return .installedFromArchive
+                }
+            } catch {
+                if skillContent == nil {
+                    throw error
+                }
+            }
+        }
+
+        guard let skillContent else {
+            throw ImportError.skillMDNotFound("ClawHub skill bundle for \(slug)")
+        }
+
+        let markdownOnlyDir = tempRoot.appendingPathComponent(slug)
+        try fm.createDirectory(at: markdownOnlyDir, withIntermediateDirectories: true)
+        let skillMDURL = markdownOnlyDir.appendingPathComponent("SKILL.md")
+        try skillContent.write(to: skillMDURL, atomically: true, encoding: .utf8)
+
+        do {
+            _ = try SkillMDParser.parse(fileURL: skillMDURL)
+        } catch {
+            throw ImportError.parseFailed(error.localizedDescription)
+        }
+
+        try await persistInstalledSkillDirectory(
+            from: markdownOnlyDir,
+            skillName: slug,
+            targetAgents: targetAgents,
+            lockEntry: entry
+        )
+        return .installedSkillMarkdownOnly
     }
 
     // MARK: - F12: Update Check
@@ -481,6 +518,9 @@ final class SkillManager {
     /// - Returns: Tuple (has update, remote tree hash, remote commit hash)
     func checkForUpdate(skill: Skill) async throws -> (hasUpdate: Bool, remoteHash: String?, remoteCommitHash: String?) {
         guard let lockEntry = skill.lockEntry else {
+            return (false, nil, nil)
+        }
+        guard lockEntry.sourceType == "github" else {
             return (false, nil, nil)
         }
 
@@ -541,7 +581,10 @@ final class SkillManager {
         // Skip local imports: they have no remote repository to compare against,
         // and trying to git-clone a local filesystem path would cause errors
         // Dictionary(grouping:by:) is similar to Java Stream's Collectors.groupingBy()
-        let skillsWithLock = skills.filter { $0.lockEntry != nil && $0.lockEntry?.sourceType != "local" }
+        let skillsWithLock = skills.filter { skill in
+            guard let sourceType = skill.lockEntry?.sourceType else { return false }
+            return sourceType == "github"
+        }
 
         // Set all skills to be checked to .checking state
         // So UI list immediately shows spinner, user knows which skills are being checked
@@ -638,6 +681,7 @@ final class SkillManager {
     ///   - remoteHash: Remote latest tree hash
     func updateSkill(_ skill: Skill, remoteHash: String) async throws {
         guard let lockEntry = skill.lockEntry else { return }
+        guard lockEntry.sourceType == "github" else { return }
 
         // Derive folderPath
         let folderPath: String
@@ -743,6 +787,85 @@ final class SkillManager {
     func saveRepoHistory(source: String, sourceUrl: String) async {
         await commitHashCache.addRepoHistory(source: source, sourceUrl: sourceUrl)
         try? await commitHashCache.save()
+    }
+
+    /// Shared persistence helper used by GitHub installs, local imports, and ClawHub installs.
+    ///
+    /// The source directory is copied into SkillDeck's canonical storage first, then symlinks are
+    /// created for each selected Agent. Keeping that order matters because Agent directories should
+    /// always point at a fully materialized canonical directory rather than a temporary location.
+    private func persistInstalledSkillDirectory(
+        from sourceURL: URL,
+        skillName: String,
+        targetAgents: Set<AgentType>,
+        lockEntry: LockEntry
+    ) async throws {
+        let fm = FileManager.default
+        let canonicalDir = SkillScanner.sharedSkillsURL.appendingPathComponent(skillName)
+
+        if fm.fileExists(atPath: canonicalDir.path) {
+            try fm.removeItem(at: canonicalDir)
+        }
+
+        if !fm.fileExists(atPath: SkillScanner.sharedSkillsURL.path) {
+            try fm.createDirectory(at: SkillScanner.sharedSkillsURL, withIntermediateDirectories: true)
+        }
+
+        try fm.copyItem(at: sourceURL, to: canonicalDir)
+
+        for agent in targetAgents {
+            try? SymlinkManager.createSymlink(from: canonicalDir, to: agent)
+        }
+
+        try await lockFileManager.createIfNotExists()
+        try await lockFileManager.updateEntry(skillName: skillName, entry: lockEntry)
+        await refresh()
+    }
+
+    /// Extract a zip archive using macOS `ditto`.
+    ///
+    /// Using `Process` here mirrors the existing updater implementation and avoids adding a zip
+    /// dependency. `ditto -xk` is reliable on macOS for ordinary zip archives and preserves links.
+    private func extractZipArchive(at archiveURL: URL, to destinationURL: URL) throws {
+        let unzipProcess = Process()
+        unzipProcess.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        unzipProcess.arguments = ["-xk", archiveURL.path, destinationURL.path]
+
+        try unzipProcess.run()
+        unzipProcess.waitUntilExit()
+
+        guard unzipProcess.terminationStatus == 0 else {
+            throw ImportError.parseFailed("Failed to extract ClawHub archive.")
+        }
+    }
+
+    /// Recursively search the extracted bundle for the first directory containing `SKILL.md`.
+    ///
+    /// ClawHub archives can wrap the skill in an extra top-level folder, so we cannot assume the
+    /// first extracted directory is the actual skill root. Walking the tree keeps this robust.
+    private func locateSkillDirectory(in rootURL: URL) throws -> URL? {
+        let fm = FileManager.default
+        if fm.fileExists(atPath: rootURL.appendingPathComponent("SKILL.md").path) {
+            return rootURL
+        }
+
+        guard let enumerator = fm.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+
+        for case let fileURL as URL in enumerator {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isDirectoryKey])
+            guard resourceValues.isDirectory == true else { continue }
+            if fm.fileExists(atPath: fileURL.appendingPathComponent("SKILL.md").path) {
+                return fileURL
+            }
+        }
+
+        return nil
     }
 
     /// Filter skills by Agent

--- a/Sources/SkillDeck/ViewModels/ClawHubBrowserViewModel.swift
+++ b/Sources/SkillDeck/ViewModels/ClawHubBrowserViewModel.swift
@@ -1,0 +1,362 @@
+import Foundation
+import Observation
+
+/// ClawHubBrowserViewModel owns all UI state for the dedicated ClawHub page.
+///
+/// This mirrors the role of `RegistryBrowserViewModel`, but keeps ClawHub-specific networking,
+/// install rules, and installed-state matching isolated from the existing skills.sh flow.
+@MainActor
+@Observable
+final class ClawHubBrowserViewModel {
+
+    /// Small alert payload for install results and recoverable errors.
+    ///
+    /// Using an `Identifiable` value works well with `.alert(item:)`, because SwiftUI can present
+    /// and dismiss the alert by simply toggling the optional between `nil` and a concrete value.
+    struct Notice: Identifiable {
+        let id = UUID()
+        let title: String
+        let message: String
+    }
+
+    /// Text currently entered in the toolbar search field.
+    var searchText = ""
+
+    /// Browse-list sort controls.
+    ///
+    /// These map directly to ClawHub's `/skills` query parameters and are only applied to the
+    /// non-search listing, because the search endpoint currently uses a separate contract.
+    var selectedSort: ClawHubService.SkillSort = .default
+    var selectedDirection: ClawHubService.SortDirection = .descending
+    var highlightedOnly = false
+    var nonSuspiciousOnly = false
+
+    /// Skills shown in the list pane.
+    var displayedSkills: [ClawHubSkill] = []
+
+    /// Whether the initial list or a search request is currently loading.
+    var isLoading = false
+
+    /// General list-level error message.
+    var errorMessage: String?
+
+    /// Selected list row ID for NavigationSplitView detail coordination.
+    var selectedSkillID: String?
+
+    /// Detailed metadata for the selected skill.
+    var selectedSkillDetail: ClawHubSkillDetail?
+
+    /// Parsed `SKILL.md` content for markdown rendering.
+    var fetchedContent: SkillMDParser.ParseResult?
+
+    /// Detail loading state is separate from content loading because either request can fail alone.
+    var isLoadingDetail = false
+    var isLoadingContent = false
+    var detailError: String?
+    var contentError: String?
+
+    /// Whether an install request is currently running, tracked by slug so only the active row
+    /// and detail button show a spinner / disabled state.
+    var installingSkillSlug: String?
+
+    /// Optional alert presented after installs or recoverable errors.
+    var notice: Notice?
+
+    /// We treat any non-empty search field as search mode.
+    var isSearchActive: Bool {
+        !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Convenience lookup for the selected list item.
+    var selectedSkill: ClawHubSkill? {
+        guard let selectedSkillID else { return nil }
+        return displayedSkills.first { $0.id == selectedSkillID }
+    }
+
+    private let service: ClawHubService
+    private let skillManager: SkillManager
+    private var installedClawHubSlugs = Set<String>()
+    private var installedSkillIDsNoSource = Set<String>()
+    private var hasLoadedInitialSkills = false
+    private var searchTask: Task<Void, Never>?
+    private var currentDetailSlug: String?
+
+    init(skillManager: SkillManager, service: ClawHubService = ClawHubService()) {
+        self.skillManager = skillManager
+        self.service = service
+    }
+
+    // MARK: - Lifecycle / list loading
+
+    /// Initial page load.
+    func onAppear() async {
+        syncInstalledSkills()
+
+        guard !hasLoadedInitialSkills else { return }
+        hasLoadedInitialSkills = true
+        await loadFeaturedSkills()
+    }
+
+    /// Refresh the currently visible list mode.
+    func refresh() async {
+        syncInstalledSkills()
+
+        if isSearchActive {
+            await performSearch(query: searchText)
+        } else {
+            await loadFeaturedSkills()
+        }
+    }
+
+    /// Debounced search handler used by `.onChange(of: searchText)`.
+    func onSearchTextChanged() {
+        searchTask?.cancel()
+
+        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedQuery.isEmpty {
+            Task { await loadFeaturedSkills() }
+            return
+        }
+
+        searchTask = Task {
+            // Debounce prevents firing a network request on every keystroke.
+            // This is similar to a frontend `setTimeout(..., 300)` search box pattern.
+            try? await Task.sleep(nanoseconds: 350_000_000)
+            guard !Task.isCancelled else { return }
+            await performSearch(query: trimmedQuery)
+        }
+    }
+
+    /// Update the browse sort chip selection.
+    func selectSort(_ sort: ClawHubService.SkillSort) {
+        guard selectedSort != sort else { return }
+        selectedSort = sort
+        reloadBrowseListIfNeeded()
+    }
+
+    /// Update ascending/descending ordering for the browse list.
+    func selectDirection(_ direction: ClawHubService.SortDirection) {
+        guard selectedDirection != direction else { return }
+        selectedDirection = direction
+        reloadBrowseListIfNeeded()
+    }
+
+    /// Toggle the `highlighted=true` filter used by the ClawHub website.
+    func toggleHighlightedOnly() {
+        highlightedOnly.toggle()
+        reloadBrowseListIfNeeded()
+    }
+
+    /// Toggle the `nonSuspicious=true` filter used by the ClawHub website.
+    func toggleNonSuspiciousOnly() {
+        nonSuspiciousOnly.toggle()
+        reloadBrowseListIfNeeded()
+    }
+
+    /// Refresh the installed badge cache from SkillManager's local skill list.
+    func syncInstalledSkills() {
+        installedClawHubSlugs = Set(
+            skillManager.skills.compactMap { skill in
+                guard skill.lockEntry?.sourceType == "clawhub" else { return nil }
+                return skill.lockEntry?.source
+            }
+        )
+
+        installedSkillIDsNoSource = Set(
+            skillManager.skills.compactMap { skill in
+                guard skill.lockEntry == nil else { return nil }
+                return skill.id
+            }
+        )
+    }
+
+    /// Determine whether a ClawHub skill is already installed locally.
+    func isInstalled(_ skill: ClawHubSkill) -> Bool {
+        if installedClawHubSlugs.contains(skill.slug) {
+            return true
+        }
+
+        return installedSkillIDsNoSource.contains(skill.slug)
+    }
+
+    /// Whether a specific row/detail action should show install progress.
+    func isInstalling(_ skill: ClawHubSkill) -> Bool {
+        installingSkillSlug == skill.slug
+    }
+
+    // MARK: - Detail loading
+
+    /// Load both metadata and `SKILL.md` content for the selected skill.
+    ///
+    /// The stale-result guards are important: SwiftUI can keep a previous async task alive for a
+    /// short time while the user clicks another row, so we only apply results if the same slug is
+    /// still selected when the request finishes.
+    func loadSelection(for skill: ClawHubSkill) async {
+        currentDetailSlug = skill.slug
+        selectedSkillDetail = nil
+        fetchedContent = nil
+        detailError = nil
+        contentError = nil
+        isLoadingDetail = true
+        isLoadingContent = true
+
+        let targetSlug = skill.slug
+
+        do {
+            let detail = try await service.fetchSkillDetail(slug: targetSlug)
+            guard currentDetailSlug == targetSlug else { return }
+            selectedSkillDetail = detail
+        } catch {
+            guard currentDetailSlug == targetSlug else { return }
+            detailError = error.localizedDescription
+        }
+        isLoadingDetail = false
+
+        do {
+            let rawContent = try await service.fetchSkillContent(slug: targetSlug)
+            guard currentDetailSlug == targetSlug else { return }
+
+            do {
+                fetchedContent = try SkillMDParser.parse(content: rawContent)
+            } catch {
+                // ClawHub skills are expected to use SKILL.md frontmatter, but we still keep a
+                // markdown-only fallback so users can read imperfect community packages.
+                fetchedContent = SkillMDParser.ParseResult(
+                    metadata: SkillMetadata(name: skill.name, description: skill.descriptionText),
+                    markdownBody: rawContent.trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+            }
+        } catch {
+            guard currentDetailSlug == targetSlug else { return }
+            contentError = error.localizedDescription
+        }
+        isLoadingContent = false
+    }
+
+    // MARK: - Installation
+
+    /// Install a ClawHub skill into SkillDeck's canonical directory and symlink it to OpenClaw.
+    func installSkill(_ skill: ClawHubSkill) {
+        guard installingSkillSlug == nil else { return }
+
+        Task {
+            await performInstall(skill)
+        }
+    }
+
+    private func performInstall(_ skill: ClawHubSkill) async {
+        installingSkillSlug = skill.slug
+        defer { installingSkillSlug = nil }
+
+        do {
+            let detail = try await service.fetchSkillDetail(slug: skill.slug)
+            guard let version = detail.installVersion else {
+                throw SkillManager.ImportError.parseFailed("ClawHub did not provide a version for \(skill.slug).")
+            }
+
+            var archiveData: Data?
+            var archiveDownloadError: Error?
+            do {
+                archiveData = try await service.downloadSkillArchive(slug: skill.slug, version: version)
+            } catch {
+                archiveDownloadError = error
+            }
+
+            var skillContent: String?
+            var skillContentError: Error?
+            do {
+                skillContent = try await service.fetchSkillContent(slug: skill.slug)
+            } catch {
+                skillContentError = error
+            }
+
+            if archiveData == nil && skillContent == nil {
+                throw archiveDownloadError ?? skillContentError ?? ClawHubService.ServiceError.archiveUnavailable
+            }
+
+            let result = try await skillManager.installClawHubSkill(
+                slug: skill.slug,
+                version: version,
+                detailPageURL: skill.browserURL.absoluteString,
+                skillContent: skillContent,
+                archiveData: archiveData,
+                targetAgents: [.openClaw]
+            )
+
+            syncInstalledSkills()
+
+            if result == .installedSkillMarkdownOnly {
+                let reason = archiveDownloadError?.localizedDescription ?? "ClawHub did not return a downloadable archive for this skill version."
+                notice = Notice(
+                    title: "Installed with limited files",
+                    message: "SkillDeck installed the SKILL.md file for OpenClaw, but auxiliary files were not included. Reason: \(reason)"
+                )
+            } else {
+                notice = Notice(
+                    title: "Installed",
+                    message: "\(skill.name) is now available to OpenClaw."
+                )
+            }
+        } catch {
+            notice = Notice(title: "Installation Failed", message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func loadFeaturedSkills() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let skills = try await service.fetchSkills(options: browseOptions)
+            displayedSkills = skills
+            updateSelection(afterLoading: skills)
+        } catch {
+            displayedSkills = []
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    private func performSearch(query: String) async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let skills = try await service.searchSkills(query: query)
+            displayedSkills = skills
+            selectedSkillID = skills.first?.id
+        } catch {
+            displayedSkills = []
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    private var browseOptions: ClawHubService.BrowseOptions {
+        ClawHubService.BrowseOptions(
+            sort: selectedSort,
+            direction: selectedDirection,
+            highlightedOnly: highlightedOnly,
+            nonSuspiciousOnly: nonSuspiciousOnly
+        )
+    }
+
+    /// Only the browse list supports sort/filter query parameters, so changing those controls while
+    /// search is active should not fire extra requests.
+    private func reloadBrowseListIfNeeded() {
+        guard !isSearchActive else { return }
+        Task { await loadFeaturedSkills() }
+    }
+
+    /// Preserve the current selection when the refreshed list still contains the same skill.
+    private func updateSelection(afterLoading skills: [ClawHubSkill]) {
+        if let selectedSkillID, skills.contains(where: { $0.id == selectedSkillID }) {
+            return
+        }
+        selectedSkillID = skills.first?.id
+    }
+}

--- a/Sources/SkillDeck/Views/ContentView.swift
+++ b/Sources/SkillDeck/Views/ContentView.swift
@@ -32,6 +32,10 @@ struct ContentView: View {
     /// Created alongside other VMs in .task; manages leaderboard browsing and search
     @State private var registryVM: RegistryBrowserViewModel?
 
+    /// Dedicated ClawHub browser ViewModel
+    /// Kept separate from the skills.sh registry VM because ClawHub has its own API contract and install flow.
+    @State private var clawHubVM: ClawHubBrowserViewModel?
+
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             // Left column: sidebar navigation
@@ -47,6 +51,11 @@ struct ContentView: View {
                 if let vm = registryVM {
                     RegistryBrowserView(viewModel: vm)
                         // Registry needs wider column for skill info + install buttons
+                        .navigationSplitViewColumnWidth(min: 300, ideal: 400, max: 600)
+                }
+            } else if selectedSidebarItem == .clawHub {
+                if let vm = clawHubVM {
+                    ClawHubBrowserView(viewModel: vm)
                         .navigationSplitViewColumnWidth(min: 300, ideal: 400, max: 600)
                 }
             } else {
@@ -76,6 +85,22 @@ struct ContentView: View {
                         subtitle: "Choose a skill from the registry to view its details"
                     )
                 }
+            } else if selectedSidebarItem == .clawHub {
+                if let vm = clawHubVM, let skill = vm.selectedSkill {
+                    ClawHubSkillDetailView(
+                        skill: skill,
+                        isInstalled: vm.isInstalled(skill),
+                        isInstalling: vm.isInstalling(skill),
+                        onInstall: { vm.installSkill(skill) },
+                        viewModel: vm
+                    )
+                } else {
+                    EmptyStateView(
+                        icon: "shippingbox",
+                        title: "Select a Skill",
+                        subtitle: "Choose a skill from ClawHub to view its details"
+                    )
+                }
             } else if let skillID = selectedSkillID, let vm = detailVM {
                 SkillDetailView(skillID: skillID, viewModel: vm)
             } else {
@@ -92,6 +117,7 @@ struct ContentView: View {
             detailVM = SkillDetailViewModel(skillManager: skillManager)
             // F09: Initialize registry browser ViewModel
             registryVM = RegistryBrowserViewModel(skillManager: skillManager)
+            clawHubVM = ClawHubBrowserViewModel(skillManager: skillManager)
             await skillManager.refresh()
             // Auto-check for updates on app launch (subject to 4-hour interval limit, not every launch requests GitHub API)
             await skillManager.checkForAppUpdate()

--- a/Sources/SkillDeck/Views/Detail/SkillDetailView.swift
+++ b/Sources/SkillDeck/Views/Detail/SkillDetailView.swift
@@ -285,10 +285,12 @@ struct SkillDetailView: View {
                 Text("Package Info")
                     .font(.headline)
 
-                Spacer()
+                if supportsGitUpdates(lockEntry) {
+                    Spacer()
 
-                // F12: 更新状态指示和操作按钮
-                updateStatusView(skill)
+                    // F12: 更新状态指示和操作按钮
+                    updateStatusView(skill)
+                }
             }
 
             // Grid is macOS 14+ grid layout (similar to HTML CSS Grid)
@@ -298,7 +300,7 @@ struct SkillDetailView: View {
                     Text(lockEntry.source).textSelection(.enabled)
                 }
                 GridRow {
-                    Text("Repository").foregroundStyle(.secondary)
+                    Text(repositoryLabel(for: lockEntry)).foregroundStyle(.secondary)
                     // If sourceUrl is valid URL, show as clickable link, opens in system default browser when clicked
                     if let url = URL(string: lockEntry.sourceUrl),
                        url.scheme != nil {
@@ -311,16 +313,19 @@ struct SkillDetailView: View {
                 // Prefer displaying commit hash (can be viewed directly on GitHub),
                 // fallback to tree hash if not present (old skill not backfilled)
                 GridRow {
-                    if let commitHash = skill.localCommitHash {
+                    if supportsGitUpdates(lockEntry), let commitHash = skill.localCommitHash {
                         Text("Commit").foregroundStyle(.secondary)
                         Text(commitHash)
                             .font(.system(.body, design: .monospaced))
                             .textSelection(.enabled)
-                    } else {
+                    } else if supportsGitUpdates(lockEntry) {
                         Text("Tree Hash").foregroundStyle(.secondary)
                         Text(lockEntry.skillFolderHash)
                             .font(.system(.body, design: .monospaced))
                             .textSelection(.enabled)
+                    } else {
+                        Text("Source Type").foregroundStyle(.secondary)
+                        Text(lockEntry.sourceType.capitalized)
                     }
                 }
                 GridRow {
@@ -478,5 +483,18 @@ struct SkillDetailView: View {
 
         // No local commit hash (backfill not successful), only link to remote commit page
         return URL(string: "\(baseURL)/commit/\(remoteHash)")
+    }
+
+    /// Only GitHub-backed skills participate in the current update pipeline.
+    ///
+    /// ClawHub installs intentionally skip git-based update checks, because their `sourceUrl` points
+    /// to a marketplace page rather than a cloneable repository.
+    private func supportsGitUpdates(_ lockEntry: LockEntry) -> Bool {
+        lockEntry.sourceType == "github"
+    }
+
+    /// Adjust the UI label so marketplace installs are not described as a Git repository.
+    private func repositoryLabel(for lockEntry: LockEntry) -> String {
+        lockEntry.sourceType == "clawhub" ? "Marketplace Page" : "Repository"
     }
 }

--- a/Sources/SkillDeck/Views/Registry/ClawHubBrowserView.swift
+++ b/Sources/SkillDeck/Views/Registry/ClawHubBrowserView.swift
@@ -1,0 +1,433 @@
+import SwiftUI
+import AppKit
+
+/// ClawHubBrowserView is the dedicated marketplace page for browsing and searching ClawHub skills.
+///
+/// This intentionally mirrors the app's existing registry layout so the UX stays familiar, while
+/// still using ClawHub-specific copy, actions, and install behavior.
+struct ClawHubBrowserView: View {
+
+    /// `@Bindable` is the modern SwiftUI bridge for `@Observable` view models.
+    /// It gives us `$viewModel.searchText` style bindings without `ObservableObject` boilerplate.
+    @Bindable var viewModel: ClawHubBrowserViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if !viewModel.isSearchActive {
+                browseControls
+                Divider()
+            }
+
+            Group {
+                if viewModel.isLoading && viewModel.displayedSkills.isEmpty {
+                    loadingView
+                } else if viewModel.displayedSkills.isEmpty {
+                    emptyState
+                } else {
+                    skillList
+                }
+            }
+        }
+        .navigationTitle("ClawHub")
+        .searchable(text: $viewModel.searchText, prompt: "Search ClawHub skills...")
+        .onChange(of: viewModel.searchText) { _, _ in
+            viewModel.onSearchTextChanged()
+        }
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    Task { await viewModel.refresh() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .help("Refresh ClawHub results")
+            }
+
+            ToolbarItem {
+                Button {
+                    if let url = URL(string: "https://clawhub.ai") {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Image(systemName: "safari")
+                }
+                .help("Open ClawHub in browser")
+            }
+        }
+        .task {
+            await viewModel.onAppear()
+        }
+        .alert(item: $viewModel.notice) { notice in
+            Alert(
+                title: Text(notice.title),
+                message: Text(notice.message),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var browseControls: some View {
+        ViewThatFits(in: .horizontal) {
+            expandedBrowseControls
+            compactBrowseControls
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+
+    /// Wide layout keeps all chips on one line when the pane has enough room.
+    private var expandedBrowseControls: some View {
+        HStack(spacing: 4) {
+            sortControls
+
+            Divider()
+                .frame(height: 20)
+                .padding(.horizontal, 4)
+
+            directionControls
+
+            Divider()
+                .frame(height: 20)
+                .padding(.horizontal, 4)
+
+            filterControls
+
+            Spacer()
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+    }
+
+    /// Narrow panes switch to compact menus so the controls stay aligned instead of wrapping chips
+    /// into an awkward multi-row layout.
+    private var compactBrowseControls: some View {
+        HStack(spacing: 8) {
+            Menu {
+                ForEach(ClawHubService.SkillSort.allCases) { sort in
+                    Button {
+                        viewModel.selectSort(sort)
+                    } label: {
+                        menuRowLabel(
+                            title: sort.displayName,
+                            systemImage: sortIconName(sort),
+                            isSelected: viewModel.selectedSort == sort
+                        )
+                    }
+                }
+            } label: {
+                compactMenuChip(
+                    title: viewModel.selectedSort.displayName,
+                    systemImage: sortIconName(viewModel.selectedSort),
+                    isSelected: viewModel.selectedSort != .default
+                )
+            }
+
+            Menu {
+                ForEach(ClawHubService.SortDirection.allCases) { direction in
+                    Button {
+                        viewModel.selectDirection(direction)
+                    } label: {
+                        menuRowLabel(
+                            title: direction.displayName,
+                            systemImage: direction == .descending ? "arrow.down" : "arrow.up",
+                            isSelected: viewModel.selectedDirection == direction
+                        )
+                    }
+                }
+            } label: {
+                compactMenuChip(
+                    title: viewModel.selectedDirection.displayName,
+                    systemImage: viewModel.selectedDirection == .descending ? "arrow.down" : "arrow.up",
+                    isSelected: viewModel.selectedSort != .default
+                )
+            }
+            .disabled(viewModel.selectedSort == .default)
+
+            Menu {
+                Button {
+                    viewModel.toggleHighlightedOnly()
+                } label: {
+                    menuRowLabel(
+                        title: "Highlighted",
+                        systemImage: "sparkles",
+                        isSelected: viewModel.highlightedOnly
+                    )
+                }
+
+                Button {
+                    viewModel.toggleNonSuspiciousOnly()
+                } label: {
+                    menuRowLabel(
+                        title: "Safe Only",
+                        systemImage: "checkmark.shield",
+                        isSelected: viewModel.nonSuspiciousOnly
+                    )
+                }
+            } label: {
+                compactMenuChip(
+                    title: compactFilterTitle,
+                    systemImage: compactFilterIconName,
+                    isSelected: viewModel.highlightedOnly || viewModel.nonSuspiciousOnly
+                )
+            }
+
+            Spacer(minLength: 0)
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+    }
+
+    private var sortControls: some View {
+        HStack(spacing: 4) {
+            ForEach(ClawHubService.SkillSort.allCases) { sort in
+                controlChip(isSelected: viewModel.selectedSort == sort) {
+                    viewModel.selectSort(sort)
+                } label: {
+                    Label(sort.displayName, systemImage: sortIconName(sort))
+                }
+            }
+        }
+    }
+
+    private var directionControls: some View {
+        HStack(spacing: 4) {
+            ForEach(ClawHubService.SortDirection.allCases) { direction in
+                controlChip(isSelected: viewModel.selectedDirection == direction) {
+                    viewModel.selectDirection(direction)
+                } label: {
+                    Label(
+                        direction.displayName,
+                        systemImage: direction == .descending ? "arrow.down" : "arrow.up"
+                    )
+                }
+                .disabled(viewModel.selectedSort == .default)
+            }
+        }
+    }
+
+    private var filterControls: some View {
+        HStack(spacing: 4) {
+            controlChip(isSelected: viewModel.highlightedOnly) {
+                viewModel.toggleHighlightedOnly()
+            } label: {
+                Label("Highlighted", systemImage: "sparkles")
+            }
+
+            controlChip(isSelected: viewModel.nonSuspiciousOnly) {
+                viewModel.toggleNonSuspiciousOnly()
+            } label: {
+                Label("Safe Only", systemImage: "checkmark.shield")
+            }
+        }
+    }
+
+    private var loadingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .controlSize(.large)
+            Text(viewModel.isSearchActive ? "Searching ClawHub..." : "Loading ClawHub skills...")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var skillList: some View {
+        List(viewModel.displayedSkills, selection: $viewModel.selectedSkillID) { skill in
+            ClawHubSkillRowView(
+                skill: skill,
+                isInstalled: viewModel.isInstalled(skill),
+                isInstalling: viewModel.isInstalling(skill),
+                onInstall: { viewModel.installSkill(skill) }
+            )
+            .tag(skill.id)
+        }
+        .listStyle(.inset(alternatesRowBackgrounds: true))
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if let errorMessage = viewModel.errorMessage {
+            VStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 40))
+                    .foregroundStyle(.orange)
+                Text("Unable to load ClawHub")
+                    .font(.title3)
+                    .fontWeight(.medium)
+                Text(errorMessage)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                Button("Try Again") {
+                    Task { await viewModel.refresh() }
+                }
+                .buttonStyle(.bordered)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if viewModel.isSearchActive {
+            EmptyStateView(
+                icon: "magnifyingglass",
+                title: "No Results",
+                subtitle: "No ClawHub skills match \"\(viewModel.searchText)\""
+            )
+        } else {
+            EmptyStateView(
+                icon: "shippingbox",
+                title: "No Skills",
+                subtitle: "ClawHub did not return any skills"
+            )
+        }
+    }
+
+    /// Reusable chip control styled to match Registry's lightweight tab appearance.
+    @ViewBuilder
+    private func controlChip<Content: View>(
+        isSelected: Bool,
+        action: @escaping () -> Void,
+        @ViewBuilder label: () -> Content
+    ) -> some View {
+        Button(action: action) {
+            label()
+                .font(.subheadline)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .fixedSize(horizontal: true, vertical: false)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Compact menu labels share the same visual language as the chips but occupy predictable width.
+    @ViewBuilder
+    private func compactMenuChip(title: String, systemImage: String, isSelected: Bool) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: systemImage)
+            Text(title)
+            Image(systemName: "chevron.down")
+                .font(.caption2)
+        }
+        .font(.subheadline)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .fixedSize(horizontal: true, vertical: false)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
+        )
+    }
+
+    @ViewBuilder
+    private func menuRowLabel(title: String, systemImage: String, isSelected: Bool) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: systemImage)
+            Text(title)
+            Spacer(minLength: 12)
+            if isSelected {
+                Image(systemName: "checkmark")
+            }
+        }
+    }
+
+    private var compactFilterTitle: String {
+        switch (viewModel.highlightedOnly, viewModel.nonSuspiciousOnly) {
+        case (false, false):
+            return "Filters"
+        case (true, false):
+            return "Highlighted"
+        case (false, true):
+            return "Safe Only"
+        case (true, true):
+            return "Highlighted + Safe"
+        }
+    }
+
+    private var compactFilterIconName: String {
+        viewModel.highlightedOnly || viewModel.nonSuspiciousOnly
+            ? "line.3.horizontal.decrease.circle.fill"
+            : "line.3.horizontal.decrease.circle"
+    }
+
+    private func sortIconName(_ sort: ClawHubService.SkillSort) -> String {
+        switch sort {
+        case .default:
+            return "arrow.up.arrow.down.circle"
+        case .downloads:
+            return "arrow.down.circle"
+        case .stars:
+            return "star"
+        }
+    }
+}
+
+/// Small list-row view kept in the same file because it is only used by ClawHubBrowserView.
+private struct ClawHubSkillRowView: View {
+    let skill: ClawHubSkill
+    let isInstalled: Bool
+    let isInstalling: Bool
+    let onInstall: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 8) {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text(skill.name)
+                            .font(.headline)
+
+                        if isInstalled {
+                            Text("Installed")
+                                .font(.caption)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 3)
+                                .background(Color.green.opacity(0.15))
+                                .foregroundStyle(.green)
+                                .clipShape(Capsule())
+                        }
+                    }
+
+                    Text(skill.descriptionText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: 12)
+
+                Button(isInstalling ? "Installing..." : "Install") {
+                    onInstall()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(isInstalled || isInstalling)
+            }
+
+            HStack(spacing: 12) {
+                Label(skill.formattedDownloads, systemImage: "arrow.down.circle")
+                Label(skill.formattedStars, systemImage: "star")
+
+                if let version = skill.latestVersion {
+                    Label(version, systemImage: "tag")
+                }
+
+                if let updatedDate = skill.formattedUpdatedDate {
+                    Label(updatedDate, systemImage: "clock")
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/Sources/SkillDeck/Views/Registry/ClawHubSkillDetailView.swift
+++ b/Sources/SkillDeck/Views/Registry/ClawHubSkillDetailView.swift
@@ -1,0 +1,311 @@
+import SwiftUI
+import AppKit
+
+/// ClawHubSkillDetailView shows marketplace metadata plus the full rendered SKILL.md content.
+///
+/// It follows the same three-pane pattern as the existing registry detail view, but the fields and
+/// actions are ClawHub-specific and installation always targets OpenClaw for this first release.
+struct ClawHubSkillDetailView: View {
+    let skill: ClawHubSkill
+    let isInstalled: Bool
+    let isInstalling: Bool
+    let onInstall: () -> Void
+    let viewModel: ClawHubBrowserViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                headerSection
+                Divider()
+                packageInfoSection
+                if let content = viewModel.fetchedContent {
+                    skillMetadataSection(content.metadata)
+                }
+                Divider()
+                actionsSection
+                Divider()
+                skillContentSection
+            }
+            .padding()
+        }
+        .navigationTitle(skill.name)
+        .task(id: skill.id) {
+            await viewModel.loadSelection(for: skill)
+        }
+    }
+
+    // MARK: - Sections
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(skill.name)
+                    .font(.title)
+                    .bold()
+                    .textSelection(.enabled)
+
+                if isInstalled {
+                    Text("Installed")
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Color.green.opacity(0.15))
+                        .foregroundStyle(.green)
+                        .clipShape(Capsule())
+                }
+            }
+
+            HStack(spacing: 4) {
+                Text("Slug:")
+                    .foregroundStyle(.secondary)
+                Text(skill.slug)
+                    .textSelection(.enabled)
+            }
+            .font(.subheadline)
+
+            Text(skill.descriptionText)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var packageInfoSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Package Info")
+                .font(.headline)
+
+            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 6) {
+                GridRow {
+                    Text("Marketplace").foregroundStyle(.secondary)
+                    Text("ClawHub")
+                }
+                GridRow {
+                    Text("Downloads").foregroundStyle(.secondary)
+                    Text(skill.formattedDownloads)
+                }
+                GridRow {
+                    Text("Stars").foregroundStyle(.secondary)
+                    Text(skill.formattedStars)
+                }
+                if let version = viewModel.selectedSkillDetail?.installVersion ?? skill.latestVersion {
+                    GridRow {
+                        Text("Latest Version").foregroundStyle(.secondary)
+                        Text(version).textSelection(.enabled)
+                    }
+                }
+                if let owner = ownerText {
+                    GridRow {
+                        Text("Owner").foregroundStyle(.secondary)
+                        Text(owner).textSelection(.enabled)
+                    }
+                }
+                if let updatedDate = skill.formattedUpdatedDate {
+                    GridRow {
+                        Text("Updated").foregroundStyle(.secondary)
+                        Text(updatedDate)
+                    }
+                }
+                if let publishedDate = viewModel.selectedSkillDetail?.formattedLatestVersionDate {
+                    GridRow {
+                        Text("Latest Publish Date").foregroundStyle(.secondary)
+                        Text(publishedDate)
+                    }
+                }
+                if let license = viewModel.selectedSkillDetail?.license {
+                    GridRow {
+                        Text("License").foregroundStyle(.secondary)
+                        Text(license)
+                    }
+                }
+                if let moderation = moderationText {
+                    GridRow {
+                        Text("Moderation").foregroundStyle(.secondary)
+                        Text(moderation)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .font(.subheadline)
+
+            if let detailError = viewModel.detailError {
+                Label(detailError, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func skillMetadataSection(_ metadata: SkillMetadata) -> some View {
+        let hasUsefulInfo = !metadata.description.isEmpty
+            || metadata.author != nil
+            || metadata.version != nil
+            || metadata.license != nil
+
+        if hasUsefulInfo {
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Skill Metadata")
+                    .font(.headline)
+
+                Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 6) {
+                    if !metadata.description.isEmpty {
+                        GridRow {
+                            Text("Description").foregroundStyle(.secondary)
+                            Text(metadata.description)
+                                .textSelection(.enabled)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    if let author = metadata.author {
+                        GridRow {
+                            Text("Author").foregroundStyle(.secondary)
+                            Text(author).textSelection(.enabled)
+                        }
+                    }
+                    if let version = metadata.version {
+                        GridRow {
+                            Text("Version").foregroundStyle(.secondary)
+                            Text(version).textSelection(.enabled)
+                        }
+                    }
+                    if let license = metadata.license {
+                        GridRow {
+                            Text("License").foregroundStyle(.secondary)
+                            Text(license).textSelection(.enabled)
+                        }
+                    }
+                }
+                .font(.subheadline)
+            }
+        }
+    }
+
+    private var actionsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Actions")
+                .font(.headline)
+
+            HStack(spacing: 12) {
+                Button {
+                    onInstall()
+                } label: {
+                    if isInstalling {
+                        Label {
+                            Text("Installing...")
+                        } icon: {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    } else {
+                        Label("Install to OpenClaw", systemImage: "arrow.down.circle")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isInstalled || isInstalling)
+
+                Button {
+                    NSWorkspace.shared.open(skill.browserURL)
+                } label: {
+                    Label("View on ClawHub", systemImage: "safari")
+                }
+                .buttonStyle(.bordered)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Install Target")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text("OpenClaw (installed via SkillDeck canonical directory + symlink)")
+                    .font(.system(.callout, design: .monospaced))
+                    .textSelection(.enabled)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .clipShape(.rect(cornerRadius: 6))
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    private var skillContentSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Skill Content")
+                .font(.headline)
+
+            if viewModel.isLoadingContent {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading SKILL.md from ClawHub...")
+                        .foregroundStyle(.secondary)
+                        .font(.subheadline)
+                }
+                .padding(.vertical, 20)
+                .frame(maxWidth: .infinity)
+            } else if let error = viewModel.contentError {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundStyle(.orange)
+                        Text(error)
+                            .foregroundStyle(.secondary)
+                            .font(.subheadline)
+                    }
+
+                    Button {
+                        NSWorkspace.shared.open(skill.browserURL)
+                    } label: {
+                        Label("View on ClawHub instead", systemImage: "safari")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+                .padding(.vertical, 8)
+            } else if let content = viewModel.fetchedContent {
+                if !content.markdownBody.isEmpty {
+                    MarkdownContentView(markdownText: content.markdownBody)
+                } else {
+                    Text("No content available.")
+                        .foregroundStyle(.secondary)
+                        .font(.subheadline)
+                        .italic()
+                }
+            }
+        }
+    }
+
+    private var ownerText: String? {
+        let handle = viewModel.selectedSkillDetail?.skill.ownerHandle ?? skill.ownerHandle
+        let displayName = viewModel.selectedSkillDetail?.skill.ownerDisplayName ?? skill.ownerDisplayName
+
+        switch (handle, displayName) {
+        case let (handle?, displayName?) where !displayName.isEmpty && displayName.caseInsensitiveCompare(handle) != .orderedSame:
+            return "@\(handle) (\(displayName))"
+        case let (handle?, _):
+            return "@\(handle)"
+        case let (_, displayName?) where !displayName.isEmpty:
+            return displayName
+        default:
+            return nil
+        }
+    }
+
+    private var moderationText: String? {
+        guard let detail = viewModel.selectedSkillDetail else { return nil }
+
+        switch (detail.moderationVerdict, detail.moderationSummary) {
+        case let (verdict?, summary?) where !summary.isEmpty:
+            return "\(verdict): \(summary)"
+        case let (verdict?, _):
+            return verdict
+        case let (_, summary?) where !summary.isEmpty:
+            return summary
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/SkillDeck/Views/Sidebar/SidebarView.swift
+++ b/Sources/SkillDeck/Views/Sidebar/SidebarView.swift
@@ -8,6 +8,8 @@ enum SidebarItem: Hashable {
     case dashboard
     /// F09: Browse skills.sh catalog (leaderboard + search)
     case registry
+    /// Browse the ClawHub marketplace for OpenClaw-compatible skills
+    case clawHub
     case agent(AgentType)
     case settings
 
@@ -19,7 +21,7 @@ enum SidebarItem: Hashable {
         switch self {
         case .agent(let agentType):
             return agentType
-        case .dashboard, .settings, .registry:
+        case .dashboard, .settings, .registry, .clawHub:
             return nil
         }
     }
@@ -80,6 +82,14 @@ struct SidebarView: View {
                 .listRowBackground(
                     RoundedRectangle(cornerRadius: 6)
                         .fill(rowBackground(for: .registry))
+                )
+
+                sidebarRow(item: .clawHub) {
+                    Label("ClawHub", systemImage: "shippingbox")
+                }
+                .listRowBackground(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(rowBackground(for: .clawHub))
                 )
             }
 
@@ -175,7 +185,10 @@ struct SidebarView: View {
                                 .controlSize(.small)
                             // Progress count: counts number of skills that have completed checking / total pending check count
                             // Skills in .checking state are still being checked, others (.hasUpdate/.upToDate/.error) indicate completed
-                            let total = skillManager.skills.filter { $0.lockEntry != nil }.count
+                            let total = skillManager.skills.filter { skill in
+                                guard let sourceType = skill.lockEntry?.sourceType else { return false }
+                                return sourceType != "local" && sourceType != "clawhub"
+                            }.count
                             // compactMap is similar to Java Stream's filter+map combination:
                             // first get value from dictionary (may be nil), then filter out .checking state
                             let checked = skillManager.updateStatuses.values.filter {

--- a/Tests/SkillDeckTests/ClawHubBrowserViewModelTests.swift
+++ b/Tests/SkillDeckTests/ClawHubBrowserViewModelTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import SkillDeck
+
+/// Unit tests for ClawHubBrowserViewModel's installed-state matching rules.
+///
+/// The ClawHub flow stores `sourceType = "clawhub"` and uses the marketplace slug as `source`, so
+/// the ViewModel should prefer slug-aware matching instead of generic skill-name heuristics.
+@MainActor
+final class ClawHubBrowserViewModelTests: XCTestCase {
+
+    private func makeSkill(id: String, source: String? = nil, sourceType: String = "clawhub") -> Skill {
+        let lockEntry: LockEntry? = source.map { src in
+            LockEntry(
+                source: src,
+                sourceType: sourceType,
+                sourceUrl: "https://clawhub.ai/skills/\(src)",
+                skillPath: "\(id)/SKILL.md",
+                skillFolderHash: "",
+                installedAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z"
+            )
+        }
+
+        return Skill(
+            id: id,
+            canonicalURL: URL(fileURLWithPath: "/tmp/skills/\(id)"),
+            metadata: SkillMetadata(name: id, description: ""),
+            markdownBody: "",
+            scope: .sharedGlobal,
+            installations: [],
+            lockEntry: lockEntry
+        )
+    }
+
+    private func makeClawHubSkill(slug: String) -> ClawHubSkill {
+        ClawHubSkill(
+            slug: slug,
+            displayName: slug,
+            summary: "",
+            latestVersion: "1.0.0",
+            downloads: 10,
+            stars: 2,
+            versionCount: 1,
+            ownerHandle: "skills",
+            ownerDisplayName: nil,
+            updatedAtMilliseconds: nil
+        )
+    }
+
+    func testIsInstalledReturnsTrueWhenClawHubSourceMatchesSlug() {
+        let skillManager = SkillManager()
+        skillManager.skills = [makeSkill(id: "browser-use", source: "browser-use")]
+
+        let viewModel = ClawHubBrowserViewModel(skillManager: skillManager)
+        viewModel.syncInstalledSkills()
+
+        XCTAssertTrue(viewModel.isInstalled(makeClawHubSkill(slug: "browser-use")))
+    }
+
+    func testIsInstalledReturnsFalseWhenClawHubSourceDiffers() {
+        let skillManager = SkillManager()
+        skillManager.skills = [makeSkill(id: "browser-use", source: "other-skill")]
+
+        let viewModel = ClawHubBrowserViewModel(skillManager: skillManager)
+        viewModel.syncInstalledSkills()
+
+        XCTAssertFalse(viewModel.isInstalled(makeClawHubSkill(slug: "browser-use")))
+    }
+
+    func testIsInstalledFallsBackToSkillIDForManualInstall() {
+        let skillManager = SkillManager()
+        skillManager.skills = [makeSkill(id: "browser-use", source: nil)]
+
+        let viewModel = ClawHubBrowserViewModel(skillManager: skillManager)
+        viewModel.syncInstalledSkills()
+
+        XCTAssertTrue(viewModel.isInstalled(makeClawHubSkill(slug: "browser-use")))
+    }
+}

--- a/Tests/SkillDeckTests/ClawHubServiceModelTests.swift
+++ b/Tests/SkillDeckTests/ClawHubServiceModelTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import SkillDeck
+
+/// Decode-focused tests for ClawHub model mapping.
+///
+/// These tests avoid live networking and instead lock down the API fields we already verified while
+/// researching issue #17. That keeps the tests stable and still protects us against accidental model
+/// regressions when refactoring the service layer.
+final class ClawHubServiceModelTests: XCTestCase {
+
+    func testClawHubSkillFormatsBrowserURLAndCounts() {
+        let skill = ClawHubSkill(
+            slug: "browser-use",
+            displayName: "Browser Use",
+            summary: "Automation skill",
+            latestVersion: "1.0.2",
+            downloads: 21466,
+            stars: 50,
+            versionCount: 3,
+            ownerHandle: "skills",
+            ownerDisplayName: nil,
+            updatedAtMilliseconds: 1773025618143
+        )
+
+        XCTAssertEqual(skill.browserURL.absoluteString, "https://clawhub.ai/skills/browser-use")
+        XCTAssertEqual(skill.formattedDownloads, "21,466")
+        XCTAssertEqual(skill.formattedStars, "50")
+        XCTAssertEqual(skill.name, "Browser Use")
+        XCTAssertNotNil(skill.formattedUpdatedDate)
+    }
+
+    func testClawHubSkillDetailPrefersDetailVersion() {
+        let skill = ClawHubSkill(
+            slug: "browser-use",
+            displayName: "Browser Use",
+            summary: "Automation skill",
+            latestVersion: nil,
+            downloads: 0,
+            stars: 0,
+            versionCount: nil,
+            ownerHandle: nil,
+            ownerDisplayName: nil,
+            updatedAtMilliseconds: nil
+        )
+
+        let detail = ClawHubSkillDetail(
+            skill: skill,
+            latestVersion: "1.0.2",
+            latestVersionCreatedAt: 1771476812023,
+            latestChangelog: "Updated docs",
+            license: nil,
+            moderationVerdict: nil,
+            moderationSummary: nil
+        )
+
+        XCTAssertEqual(detail.installVersion, "1.0.2")
+        XCTAssertNotNil(detail.formattedLatestVersionDate)
+    }
+
+    func testBrowseOptionsBuildExpectedQueryItems() {
+        let options = ClawHubService.BrowseOptions(
+            sort: .stars,
+            direction: .ascending,
+            highlightedOnly: true,
+            nonSuspiciousOnly: true,
+            limit: 25
+        )
+
+        XCTAssertEqual(
+            options.queryItems,
+            [
+                URLQueryItem(name: "limit", value: "25"),
+                URLQueryItem(name: "sort", value: "stars"),
+                URLQueryItem(name: "dir", value: "asc"),
+                URLQueryItem(name: "highlighted", value: "true"),
+                URLQueryItem(name: "nonSuspicious", value: "true")
+            ]
+        )
+    }
+
+    func testBrowseOptionsOmitSortParametersForDefaultOrdering() {
+        let options = ClawHubService.BrowseOptions()
+        let names = options.queryItems.map(\.name)
+
+        XCTAssertEqual(options.queryItems.first, URLQueryItem(name: "limit", value: "50"))
+        XCTAssertFalse(names.contains("sort"))
+        XCTAssertFalse(names.contains("dir"))
+    }
+}

--- a/Tests/SkillDeckTests/LocalImportTests.swift
+++ b/Tests/SkillDeckTests/LocalImportTests.swift
@@ -238,9 +238,10 @@ final class LocalImportTests: XCTestCase {
         XCTAssertEqual(readEntry?.skillFolderHash, "", "skillFolderHash should be empty for local imports")
     }
 
-    /// Test that local skills are filtered out in checkAllUpdates filter logic
-    /// This verifies the filtering condition: sourceType != "local"
-    func testLocalSkillsSkippedInUpdateCheck() {
+    /// Test that only GitHub-backed skills participate in the current update-check pipeline.
+    ///
+    /// This mirrors SkillManager.checkAllUpdates(), which now explicitly keeps only `sourceType == "github"`.
+    func testOnlyGitHubSkillsParticipateInUpdateCheck() {
         // Create lock entries for both types
         let githubEntry = LockEntry(
             source: "owner/repo",
@@ -262,15 +263,46 @@ final class LocalImportTests: XCTestCase {
             updatedAt: "2024-01-01T00:00:00Z"
         )
 
+        let clawHubEntry = LockEntry(
+            source: "browser-use",
+            sourceType: "clawhub",
+            sourceUrl: "https://clawhub.ai/skills/browser-use",
+            skillPath: "browser-use/SKILL.md",
+            skillFolderHash: "",
+            installedAt: "2024-01-01T00:00:00Z",
+            updatedAt: "2024-01-01T00:00:00Z"
+        )
+
         // Simulate the filter logic from checkAllUpdates()
-        // This is the exact condition used in SkillManager.checkAllUpdates():
-        // skills.filter { $0.lockEntry != nil && $0.lockEntry?.sourceType != "local" }
-        let entries: [LockEntry?] = [githubEntry, localEntry, nil]
-        let filtered = entries.filter { $0 != nil && $0?.sourceType != "local" }
+        let entries: [LockEntry?] = [githubEntry, localEntry, clawHubEntry, nil]
+        let filtered = entries.compactMap { $0 }.filter { $0.sourceType == "github" }
 
         // Only the GitHub entry should pass the filter
-        XCTAssertEqual(filtered.count, 1, "Only non-local entries should pass the filter")
-        XCTAssertEqual(filtered.first??.sourceType, "github")
+        XCTAssertEqual(filtered.count, 1, "Only GitHub entries should pass the filter")
+        XCTAssertEqual(filtered.first?.sourceType, "github")
+    }
+
+    /// Test that lock entry fields for ClawHub installs preserve marketplace-specific metadata.
+    func testLockEntryFieldsForClawHubInstall() async throws {
+        let now = ISO8601DateFormatter().string(from: Date())
+        let entry = LockEntry(
+            source: "browser-use",
+            sourceType: "clawhub",
+            sourceUrl: "https://clawhub.ai/skills/browser-use",
+            skillPath: "browser-use/SKILL.md",
+            skillFolderHash: "",
+            installedAt: now,
+            updatedAt: now
+        )
+        try await lockFileManager.updateEntry(skillName: "browser-use", entry: entry)
+
+        let readEntry = try await lockFileManager.getEntry(skillName: "browser-use")
+        XCTAssertNotNil(readEntry)
+        XCTAssertEqual(readEntry?.source, "browser-use")
+        XCTAssertEqual(readEntry?.sourceType, "clawhub")
+        XCTAssertEqual(readEntry?.sourceUrl, "https://clawhub.ai/skills/browser-use")
+        XCTAssertEqual(readEntry?.skillPath, "browser-use/SKILL.md")
+        XCTAssertEqual(readEntry?.skillFolderHash, "")
     }
 
     // MARK: - ImportError Tests


### PR DESCRIPTION
## Summary
- add a dedicated ClawHub sidebar section with browse, search, detail, sorting, and filtering support
- install ClawHub skills into SkillDeck's canonical storage and symlink them for OpenClaw without depending on clawhub CLI or .clawhub/lock.json
- handle ClawHub rate limits gracefully by falling back to SKILL.md-only installs and keeping filter controls available during error states
- add model and view model coverage for ClawHub parsing, browse options, and installed-state detection

Closes #17

## Testing
- swift test

## Manual Verification Required
- verify the new ClawHub sidebar entry loads the browse page and detail pane correctly in the macOS app
- verify a real ClawHub skill can be installed and appears under OpenClaw via the canonical directory plus symlink flow
- verify the compact browse controls remain usable in narrow widths and still show the selected sort, direction, and filter labels
- verify the rate-limit fallback message and limited-files install behavior remain understandable in the UI when ClawHub returns HTTP 429

## Regression Checklist
- confirm the existing skills.sh Registry page still loads leaderboards, search results, and detail content
- confirm GitHub/local skill installation flows still populate the canonical skill directory and agent symlinks correctly
- confirm installed skill detail pages still render markdown content and metadata without layout regressions
- confirm update checks continue to work for supported non-ClawHub sources and skip ClawHub entries safely
