### PR TITLE
fix: align local translation with a canonical language pair

### DIFF
--- a/Sources/SkillDeck/Services/TranslationLanguagePair.swift
+++ b/Sources/SkillDeck/Services/TranslationLanguagePair.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+#if canImport(Translation)
+import Translation
+#endif
+
+/// Centralized source/target `Locale.Language` values for Apple's Translation framework.
+///
+/// This is intentionally separate from `AppLanguage`: the app stores generic UI language tags
+/// such as `en` and `zh-Hans`, while the Translation framework needs one canonical pair that both
+/// availability checks and real translation sessions can share.
+struct TranslationLanguagePair {
+    let source: Locale.Language
+
+    let target: Locale.Language
+
+    /// English (United States) → Simplified Chinese.
+    ///
+    /// We use `en-US` here instead of the broader UI tag `en` so the translation subsystem asks
+    /// Apple's framework for one explicit, shared pair instead of duplicating ad-hoc identifiers.
+    static let englishToSimplifiedChinese = TranslationLanguagePair(
+        source: Locale.Language(identifier: "en-US"),
+        target: Locale.Language(identifier: "zh-Hans")
+    )
+}

--- a/Sources/SkillDeck/Services/TranslationPackAvailabilityChecker.swift
+++ b/Sources/SkillDeck/Services/TranslationPackAvailabilityChecker.swift
@@ -14,10 +14,11 @@ struct TranslationPackAvailabilityChecker {
     func englishToSimplifiedChinese() async -> Availability {
         #if canImport(Translation) && compiler(>=6.2)
         if #available(macOS 26.0, *) {
+            let pair = TranslationLanguagePair.englishToSimplifiedChinese
             let availability = LanguageAvailability()
             let status = await availability.status(
-                from: Locale.Language(identifier: "en"),
-                to: Locale.Language(identifier: "zh-Hans")
+                from: pair.source,
+                to: pair.target
             )
 
             switch status {

--- a/Sources/SkillDeck/Services/TranslationService.swift
+++ b/Sources/SkillDeck/Services/TranslationService.swift
@@ -50,9 +50,10 @@ private struct DefaultLocalTranslationClient: LocalTranslationClient {
 @available(macOS 26.0, *)
 private struct TranslationFrameworkClient: LocalTranslationClient {
     func translateEnglishToChinese(_ text: String) async throws -> String {
+        let pair = TranslationLanguagePair.englishToSimplifiedChinese
         let session = TranslationSession(
-            installedSource: Locale.Language(identifier: "en"),
-            target: Locale.Language(identifier: "zh-Hans")
+            installedSource: pair.source,
+            target: pair.target
         )
         let response = try await session.translate(text)
         return response.targetText

--- a/Tests/SkillDeckTests/TranslationServiceTests.swift
+++ b/Tests/SkillDeckTests/TranslationServiceTests.swift
@@ -30,4 +30,15 @@ final class TranslationServiceTests: XCTestCase {
         let calls = await client.calls
         XCTAssertEqual(calls, ["Hello"])
     }
+
+    func testCanonicalEnglishToSimplifiedChineseTranslationPair_usesExplicitSupportedIdentifiers() {
+        XCTAssertEqual(
+            TranslationLanguagePair.englishToSimplifiedChinese.source,
+            Locale.Language(identifier: "en-US")
+        )
+        XCTAssertEqual(
+            TranslationLanguagePair.englishToSimplifiedChinese.target,
+            Locale.Language(identifier: "zh-Hans")
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- centralize the on-device English to Simplified Chinese translation pair in a shared service type
- make the translation availability check and TranslationSession use the same canonical `en-US -> zh-Hans` mapping
- add a regression test to lock the canonical translation pair used by the local translation path

## Test Plan
- [x] swift test
- [x] swift build