### PR TITLE
fix: sync agent toggle state correctly after toggling

### DIFF
--- a/Sources/SkillDeck/Services/SkillManager.swift
+++ b/Sources/SkillDeck/Services/SkillManager.swift
@@ -373,7 +373,10 @@ final class SkillManager {
     /// Protection logic: if inherited installation (isInherited), return directly without any operation
     /// This is Service layer defense - even if UI layer disables Toggle, it ensures inherited installations won't be mistakenly operated
     func toggleAssignment(_ skill: Skill, agent: AgentType) async throws {
-        let installation = skill.installations.first { $0.agentType == agent }
+        // Get latest skill data from self.skills to ensure we have current installations
+        let latestSkill = self.skills.first { $0.id == skill.id } ?? skill
+
+        let installation = latestSkill.installations.first { $0.agentType == agent }
 
         // Protection: inherited installations cannot be toggled (inherited installations are managed by source Agent)
         // For Codex: reading from ~/.agents/skills/ is not truly "inherited" - it's native support
@@ -392,9 +395,9 @@ final class SkillManager {
         let isInstalled = installation != nil
         print("[SkillManager] toggleAssignment: agent=\(agent.displayName), isInstalled=\(isInstalled)")
         if isInstalled {
-            try await unassignSkill(skill, from: agent)
+            try await unassignSkill(latestSkill, from: agent)
         } else {
-            try await assignSkill(skill, to: agent)
+            try await assignSkill(latestSkill, to: agent)
         }
     }
 

--- a/Sources/SkillDeck/Views/Components/AgentToggleView.swift
+++ b/Sources/SkillDeck/Views/Components/AgentToggleView.swift
@@ -11,37 +11,37 @@ struct AgentToggleView: View {
     let viewModel: SkillDetailViewModel
     @Environment(SkillManager.self) private var skillManager
 
-    /// Get the latest skill data from SkillManager to ensure UI reflects current state
-    private var skill: Skill? {
-        skillManager.skills.first { $0.id == skillID }
-    }
-
     var body: some View {
         VStack(spacing: 8) {
-            // Use skill from SkillManager directly to ensure real-time updates
-            if let skill = skill {
-                ForEach(AgentType.allCases) { agentType in
-                    AgentToggleRow(
-                        agentType: agentType,
-                        skill: skill,
-                        viewModel: viewModel
-                    )
-                }
+            // Iterate through all detected Agents
+            ForEach(AgentType.allCases) { agentType in
+                AgentToggleRow(
+                    skillID: skillID,
+                    agentType: agentType,
+                    viewModel: viewModel
+                )
             }
         }
     }
 }
 
 /// Single row for an Agent toggle
+/// Uses skillID instead of Skill to ensure proper SwiftUI dependency tracking
 private struct AgentToggleRow: View {
+    let skillID: String
     let agentType: AgentType
-    let skill: Skill
     let viewModel: SkillDetailViewModel
     @Environment(SkillManager.self) private var skillManager
 
+    /// Get the latest skill data from SkillManager to ensure real-time updates
+    /// Accessing skillManager.skills here ensures SwiftUI tracks this dependency
+    private var skill: Skill? {
+        skillManager.skills.first { $0.id == skillID }
+    }
+
     /// Find installation record for this Agent
     private var installation: SkillInstallation? {
-        skill.installations.first { $0.agentType == agentType }
+        skill?.installations.first { $0.agentType == agentType }
     }
 
     /// Whether this Agent has the skill installed
@@ -108,7 +108,10 @@ private struct AgentToggleRow: View {
                 get: { isInstalled },
                 set: { _ in
                     Task {
-                        await viewModel.toggleAgent(agentType, for: skill)
+                        // Pass the current skill from SkillManager, not the captured value
+                        if let skill = skillManager.skills.first(where: { $0.id == skillID }) {
+                            await viewModel.toggleAgent(agentType, for: skill)
+                        }
                     }
                 }
             ))

--- a/Sources/SkillDeck/Views/Install/SkillInstallView.swift
+++ b/Sources/SkillDeck/Views/Install/SkillInstallView.swift
@@ -221,7 +221,13 @@ struct SkillInstallView: View {
                             // Toggle is macOS switch/checkbox component
                             Toggle(isOn: Binding(
                                 get: { viewModel.selectedAgents.contains(agentType) },
-                                set: { _ in viewModel.toggleAgentSelection(agentType) }
+                                set: { newValue in
+                                    if newValue {
+                                        viewModel.selectedAgents.insert(agentType)
+                                    } else {
+                                        viewModel.selectedAgents.remove(agentType)
+                                    }
+                                }
                             )) {
                                 Label(agentType.displayName, systemImage: agentType.iconName).appFont(.caption)
                             }


### PR DESCRIPTION
## Summary

Fixes agent toggle UI not reflecting the correct installation state immediately after user interaction. Previously, users had to restart SkillDeck to see the updated toggle state.

## Changes

### AgentToggleView.swift
- Changed `AgentToggleRow` to receive `skillID: String` instead of `skill: Skill` parameter
- `skill` property now dynamically fetches from `skillManager.skills`, ensuring SwiftUI properly tracks dependency changes
- Toggle action now passes the freshly fetched skill to `viewModel.toggleAgent()`

### SkillManager.swift  
- `toggleAssignment()` now fetches latest skill data from `self.skills` before checking installation status
- Prevents "Target already exists" errors when symlink exists but cached skill data is stale
- Uses the latest skill data for install/uninstall operations

### SkillInstallView.swift
- Fixed Toggle binding to use explicit `newValue` instead of ignoring it
- Prevents state inconsistency when toggling agent selection in install sheet

## Root Cause

SwiftUI's dependency tracking wasn't detecting changes to `skill.installations` because:
1. `Skill` is a value type (struct), and passing it down the view hierarchy created copies
2. `AgentToggleRow` captured a specific `skill` instance that wouldn't update when `SkillManager.skills` refreshed
3. `toggleAssignment` was using potentially stale skill data from the parameter instead of the refreshed `skills` array

## Manual Verification Required

- [ ] Open a skill detail page for an installed skill
- [ ] Click the Claude Code toggle to disable it - verify toggle immediately shows OFF
- [ ] Click the toggle again to enable it - verify toggle immediately shows ON
- [ ] Verify no restart of SkillDeck is required to see correct state
- [ ] Test with skills installed to multiple agents - verify each toggle updates independently

## Regression Checklist

- [ ] Agent toggle for inherited installations still shows "via ~/.claude/skills" hint and is disabled
- [ ] Codex native support toggle still shows "Native support" hint and is disabled  
- [ ] Agent toggle for unavailable agents still shows "Not installed" hint and is disabled
- [ ] Skill installation from GitHub/Registry still works correctly
- [ ] Skill detail page loads without performance degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)