### PR TITLE
feat: add QClaw and WorkBuddy agent support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ Views → ViewModels (@Observable) → SkillManager (@Observable) → Services (
 | OpenClaw | `~/.openclaw/skills/` | `openclaw` binary | Own directory only |
 | Trae | `~/.trae/skills/` | `trae` binary | Own directory only |
 | Qoder | `~/.qoder/skills/` | `qoder` binary | Own directory only |
+| QClaw | `~/.qclaw/skills/` | `qclaw` binary | Own directory only |
+| WorkBuddy | `~/.workbuddy/skills/` | `workbuddy` binary | Own directory only |
 
 ## Testing
 

--- a/Sources/SkillDeck/Models/AgentType.swift
+++ b/Sources/SkillDeck/Models/AgentType.swift
@@ -15,6 +15,8 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
     case openClaw = "openclaw"             // OpenClaw: AI coding assistant with ClawHub registry (https://openclaw.ai)
     case trae = "trae"                       // Trae: ByteDance's AI IDE (https://trae.ai)
     case qoder = "qoder"                     // Qoder: AI coding agent (https://qoder.ai)
+    case qclaw = "qclaw"                     // QClaw: AI coding assistant (skills in ~/.qclaw/skills)
+    case workbuddy = "workbuddy"             // WorkBuddy: AI coding assistant (skills in ~/.workbuddy/skills)
 
     // Identifiable protocol requirement (similar to Java's Comparable), needed for SwiftUI list rendering
     var id: String { rawValue }
@@ -33,6 +35,8 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .openClaw: "OpenClaw"
         case .trae: "Trae"
         case .qoder: "Qoder"
+        case .qclaw: "QClaw"
+        case .workbuddy: "WorkBuddy"
         }
     }
 
@@ -52,6 +56,8 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .openClaw: "red"
         case .trae: "brightGreen"
         case .qoder: "orange"
+        case .qclaw: "mint"
+        case .workbuddy: "yellow"
         }
     }
 
@@ -71,6 +77,8 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .openClaw: "o.circle"               // Letter O icon for OpenClaw
         case .trae: "t.circle"                     // Letter T icon for Trae
         case .qoder: "q.circle"                     // Letter Q icon for Qoder
+        case .qclaw: "hand.raised.circle"            // Hand/claw icon for QClaw
+        case .workbuddy: "w.circle"                 // Letter W icon for WorkBuddy
         }
     }
 
@@ -107,6 +115,10 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
             return "~/.trae/skills"                         // Trae AI IDE skills directory
         case .qoder:
             return "~/.qoder/skills"                        // Qoder AI coding agent skills directory
+        case .qclaw:
+            return "~/.qclaw/skills"                        // QClaw AI assistant skills directory
+        case .workbuddy:
+            return "~/.workbuddy/skills"                    // WorkBuddy AI assistant skills directory
         }
     }
 
@@ -131,6 +143,8 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .openClaw: "~/.openclaw"
         case .trae: "~/.trae"
         case .qoder: "~/.qoder"
+        case .qclaw: "~/.qclaw"
+        case .workbuddy: "~/.workbuddy"
         }
     }
 
@@ -149,6 +163,8 @@ enum AgentType: String, CaseIterable, Identifiable, Codable {
         case .openClaw: "openclaw"
         case .trae: "trae"
         case .qoder: "qoder"
+        case .qclaw: "qclaw"
+        case .workbuddy: "workbuddy"
         }
     }
 

--- a/Sources/SkillDeck/Utilities/Constants.swift
+++ b/Sources/SkillDeck/Utilities/Constants.swift
@@ -22,6 +22,8 @@ enum Constants {
             case .openClaw:    Color(red: 0.85, green: 0.18, blue: 0.15)  // Red #D92E26 (lobster/crayfish theme)
             case .trae:        Color(red: 0.20, green: 0.94, blue: 0.55)  // Bright Green #32F08C
             case .qoder:       Color(red: 0.96, green: 0.52, blue: 0.15)  // Orange #F58426
+            case .qclaw:       Color(red: 0.0, green: 0.78, blue: 0.55)   // Mint #00C78B
+            case .workbuddy:   Color(red: 1.0, green: 0.80, blue: 0.0)    // Yellow #FFCC00
             }
         }
     }

--- a/Tests/SkillDeckTests/AgentTypeTests.swift
+++ b/Tests/SkillDeckTests/AgentTypeTests.swift
@@ -167,12 +167,52 @@ final class AgentTypeTests: XCTestCase {
         XCTAssertTrue(agent.additionalReadableSkillsDirectories.isEmpty)
     }
 
+    // MARK: - QClaw Agent Properties
+
+    /// Verify all computed properties of the QClaw agent type
+    /// QClaw is an AI coding assistant with standalone directory structure
+    func testQClawProperties() {
+        let agent = AgentType.qclaw
+
+        // rawValue is used as the Codable key in lock file JSON
+        XCTAssertEqual(agent.rawValue, "qclaw")
+        XCTAssertEqual(agent.displayName, "QClaw")
+        XCTAssertEqual(agent.detectCommand, "qclaw")
+        XCTAssertEqual(agent.skillsDirectoryPath, "~/.qclaw/skills")
+        XCTAssertEqual(agent.configDirectoryPath, "~/.qclaw")
+        XCTAssertEqual(agent.iconName, "hand.raised.circle")
+        XCTAssertEqual(agent.brandColor, "mint")
+
+        // QClaw does not read other agents' directories (standalone agent)
+        XCTAssertTrue(agent.additionalReadableSkillsDirectories.isEmpty)
+    }
+
+    // MARK: - WorkBuddy Agent Properties
+
+    /// Verify all computed properties of the WorkBuddy agent type
+    /// WorkBuddy is an AI coding assistant with standalone directory structure
+    func testWorkBuddyProperties() {
+        let agent = AgentType.workbuddy
+
+        // rawValue is used as the Codable key in lock file JSON
+        XCTAssertEqual(agent.rawValue, "workbuddy")
+        XCTAssertEqual(agent.displayName, "WorkBuddy")
+        XCTAssertEqual(agent.detectCommand, "workbuddy")
+        XCTAssertEqual(agent.skillsDirectoryPath, "~/.workbuddy/skills")
+        XCTAssertEqual(agent.configDirectoryPath, "~/.workbuddy")
+        XCTAssertEqual(agent.iconName, "w.circle")
+        XCTAssertEqual(agent.brandColor, "yellow")
+
+        // WorkBuddy does not read other agents' directories (standalone agent)
+        XCTAssertTrue(agent.additionalReadableSkillsDirectories.isEmpty)
+    }
+
     // MARK: - CaseIterable Count
 
     /// Verify the total number of supported agents
     /// This test catches accidental removal of agent cases
     func testAllCasesCount() {
-        // 12 agents: claudeCode, codex, geminiCLI, copilotCLI, openCode, antigravity, cursor, kiro, codeBuddy, openClaw, trae, qoder
-        XCTAssertEqual(AgentType.allCases.count, 12)
+        // 14 agents: claudeCode, codex, geminiCLI, copilotCLI, openCode, antigravity, cursor, kiro, codeBuddy, openClaw, trae, qoder, qclaw, workbuddy
+        XCTAssertEqual(AgentType.allCases.count, 14)
     }
 }


### PR DESCRIPTION
## Summary
- Added `qclaw` and `workbuddy` agent types to `AgentType` enum, enabling SkillDeck to manage skills for these two AI coding assistants
- Each agent includes full computed properties: display name, brand color, SF Symbol icon, skills directory path, config directory path, and CLI detect command
- QClaw uses `hand.raised.circle` icon (claw theme), mint brand color, skills at `~/.qclaw/skills`
- WorkBuddy uses `w.circle` icon, yellow brand color, skills at `~/.workbuddy/skills`

## Changes
- `Sources/SkillDeck/Models/AgentType.swift` — added `qclaw` and `workbuddy` cases with all computed properties
- `Sources/SkillDeck/Utilities/Constants.swift` — added brand colors for both agents
- `Tests/SkillDeckTests/AgentTypeTests.swift` — added property tests for both agents, updated `allCasesCount` from 12 to 14
- `CLAUDE.md` — updated supported agents table

## Test plan
- [x] `swift build` compiles successfully
- [x] `swift test` — all 171 tests pass with 0 failures
- [ ] Verify QClaw and WorkBuddy appear in the agent list UI
- [ ] Verify skill scanning works when `~/.qclaw/skills/` or `~/.workbuddy/skills/` directories exist

## Manual Verification Required
- Visual confirmation that QClaw and WorkBuddy icons render correctly in the sidebar (SF Symbols `hand.raised.circle` and `w.circle`)
- Brand colors (mint/yellow) display properly in agent badges

## Regression Checklist
- Existing 12 agents still display and function correctly
- Skill scanning and symlink management unaffected
- Lock file serialization/deserialization works with new agent raw values

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)