### PR TITLE
fix: make Up to Date status persistent in skill detail page

### DIFF
--- a/Sources/SkillDeck/ViewModels/SkillDetailViewModel.swift
+++ b/Sources/SkillDeck/ViewModels/SkillDetailViewModel.swift
@@ -23,8 +23,10 @@ final class SkillDetailViewModel {
     /// F12: Error message from update operation
     var updateError: String?
 
-    /// F12: Check result — whether skill is up to date (for showing "Up to Date" message)
-    var showUpToDate = false
+    // NOTE: showUpToDate was removed — the detail view now reads the persistent
+    // updateStatus from skillManager.updateStatuses[skill.id] instead of a transient flag.
+    // This ensures the "Up to Date" label stays visible until the user navigates away
+    // or triggers another action, rather than auto-disappearing after 2 seconds.
 
     // MARK: - Link to Repository State
 
@@ -106,7 +108,6 @@ final class SkillDetailViewModel {
     func checkForUpdate(skill: Skill) async {
         isCheckingUpdate = true
         updateError = nil
-        showUpToDate = false
 
         do {
             let (hasUpdate, remoteHash, remoteCommitHash) = try await skillManager.checkForUpdate(skill: skill)
@@ -133,15 +134,10 @@ final class SkillDetailViewModel {
                 skillManager.skills[index].localCommitHash = cachedLocalHash
             }
 
-            if !hasUpdate {
-                showUpToDate = true
-                // Auto-hide "Up to Date" message after 2 seconds
-                // Task.sleep is similar to Go's time.Sleep but non-blocking
-                Task {
-                    try? await Task.sleep(for: .seconds(2))
-                    showUpToDate = false
-                }
-            }
+            // NOTE: No longer setting a transient showUpToDate flag.
+            // The updateStatuses[.upToDate] set above (line 120) is persistent —
+            // the detail view reads it directly, so "Up to Date" stays visible
+            // until the user navigates away or triggers another check.
         } catch {
             updateError = error.localizedDescription
         }

--- a/Sources/SkillDeck/Views/Detail/SkillDetailView.swift
+++ b/Sources/SkillDeck/Views/Detail/SkillDetailView.swift
@@ -339,14 +339,22 @@ struct SkillDetailView: View {
 
     /// F12: Update status indicator view
     ///
-    /// Displays different UI based on viewModel's update check status:
+    /// Displays different UI based on the persistent update status from skillManager:
     /// - Checking: ProgressView + "Checking..."
     /// - Has update: orange label + "Update" button
     /// - Updating: ProgressView + "Updating..."
-    /// - Up to date: green checkmark (auto-disappears after 2 seconds)
-    /// - Default: check button
+    /// - Up to date: green checkmark (persists until user navigates away or re-checks)
+    /// - Error: warning icon + error text
+    /// - Default (notChecked): check button
+    ///
+    /// The "Up to Date" state reads from skillManager.updateStatuses[skill.id] (persistent)
+    /// rather than a transient ViewModel flag, so the user always sees the status.
     @ViewBuilder
     private func updateStatusView(_ skill: Skill) -> some View {
+        // Read the persistent update status from SkillManager (set by checkForUpdate / checkAllUpdates)
+        // This survives view refreshes and doesn't auto-disappear
+        let updateStatus = skillManager.updateStatuses[skill.id] ?? .notChecked
+
         if viewModel.isCheckingUpdate {
             // Checking for updates
             HStack(spacing: 4) {
@@ -363,7 +371,7 @@ struct SkillDetailView: View {
                 Text("Updating...").appFont(.caption)
                     .foregroundStyle(.secondary)
             }
-        } else if skill.hasUpdate {
+        } else if skill.hasUpdate || updateStatus == .hasUpdate {
             // Has available update: show hash comparison + GitHub link + Update button
             VStack(alignment: .trailing, spacing: 4) {
                 HStack(spacing: 8) {
@@ -380,12 +388,24 @@ struct SkillDetailView: View {
                 // Displays localHash → remoteHash (7-character short format, consistent with git log --oneline)
                 updateDetailRow(skill)
             }
-        } else if viewModel.showUpToDate {
-            // Already up to date (auto-disappears after 2 seconds)
-            Label("Up to Date", systemImage: "checkmark.circle.fill").appFont(.caption)
-                .foregroundStyle(.green)
+        } else if updateStatus == .upToDate {
+            // Already up to date — persistent label, stays visible until user navigates away or re-checks
+            // Previously this auto-disappeared after 2 seconds, which users could easily miss
+            HStack(spacing: 6) {
+                Label("Up to Date", systemImage: "checkmark.circle.fill").appFont(.caption)
+                    .foregroundStyle(.green)
+
+                // Small "Check Again" button so user can re-verify if needed
+                Button {
+                    Task { await viewModel.checkForUpdate(skill: skill) }
+                } label: {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                }
+                .controlSize(.mini)
+                .help("Check for updates again")
+            }
         } else if let error = viewModel.updateError {
-            // 更新检查出错
+            // Update check error
             HStack(spacing: 4) {
                 Image(systemName: "exclamationmark.triangle")
                     .foregroundStyle(.orange)
@@ -394,7 +414,7 @@ struct SkillDetailView: View {
                     .lineLimit(1)
             }
         } else {
-            // Default state: show check button
+            // Default state (notChecked): show check button
             Button {
                 Task { await viewModel.checkForUpdate(skill: skill) }
             } label: {


### PR DESCRIPTION
## Problem

When clicking "Check for updates" on a skill that is already up to date, the "Up to Date" message only displayed for 2 seconds before auto-dismissing. Users could easily miss the confirmation and wouldn't know whether their skill was current.

## Root Cause

`SkillDetailViewModel.showUpToDate` was a transient boolean flag that auto-hid after a 2-second `Task.sleep`. After it disappeared, the view fell back to showing the "Check for updates" button again — as if the check never happened.

## Solution

Replaced the transient `showUpToDate` flag with the persistent `skillManager.updateStatuses[skill.id]` dictionary (which already stores `.upToDate` after a check completes). The "Up to Date" label now stays visible until the user navigates away or triggers another check.

### Changes

**SkillDetailViewModel.swift**:
- Removed `showUpToDate` property
- Removed `showUpToDate = true` and the 2-second auto-hide `Task` in `checkForUpdate()`
- `skillManager.updateStatuses[.upToDate]` was already being set — no new persistence logic needed

**SkillDetailView.swift**:
- `updateStatusView()` now reads `skillManager.updateStatuses[skill.id]` instead of `viewModel.showUpToDate`
- When status is `.upToDate`, shows persistent green label + small "Check Again" button
- Added `.upToDate` case check alongside `skill.hasUpdate` for the update-available state

## Manual Verification Required

- Open a skill detail page → click "Check for updates" → verify "Up to Date" label persists (does not disappear after 2 seconds)
- Verify the small "Check Again" button next to "Up to Date" triggers a re-check
- Verify that after re-check, the status updates correctly (either stays "Up to Date" or switches to "Update Available")
- Verify the dashboard row update status indicator still works correctly

## Regression Checklist

- Skill detail page: "Check for updates" button works when status is `notChecked`
- Skill detail page: "Update Available" label + "Update" button still works for skills with updates
- Skill detail page: "Updating..." progress indicator still works during update
- Skill detail page: Error state still displays correctly
- Dashboard: Row-level update status indicators (green checkmark, orange dot) unchanged
- `checkAllUpdates()` batch check still populates `updateStatuses` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
