### PR TITLE
feat: 增加 Codex Skill 使用记录统计

### DIFF
--- a/Sources/SkillDeck/Models/SkillUsage.swift
+++ b/Sources/SkillDeck/Models/SkillUsage.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A single skill's usage evidence recovered from local Agent history.
+///
+/// The count intentionally represents detected invocation evidence, not a guarantee that every
+/// historical invocation was captured. Agent history can be disabled, deleted, or written in a
+/// format that an older SkillDeck release does not understand.
+struct SkillUsageRecord: Codable, Equatable {
+    /// Number of distinct Codex tool-call events that referenced this skill's `SKILL.md` file.
+    let detectedInvocationCount: Int
+
+    /// Timestamp of the newest matching tool-call event, when the log provided a valid timestamp.
+    let lastDetectedAt: Date?
+}
+
+/// Observable lifecycle state for a local usage-history scan.
+///
+/// Associated values let the `.available` case carry scan coverage without introducing a second
+/// state variable that could become inconsistent with the enum.
+enum SkillUsageScanState: Equatable {
+    /// No scan has started during this app launch.
+    case notScanned
+
+    /// SkillDeck is reading local history files in the background.
+    case scanning
+
+    /// At least one Codex history file was readable, so a missing record means "not detected".
+    case available(scannedLogCount: Int)
+
+    /// No readable Codex history files were found, so usage must be reported as unknown.
+    case unavailable
+}
+
+/// Complete result returned by an Agent-specific usage-history adapter.
+struct SkillUsageScanResult: Equatable {
+    /// Records are keyed by the skill directory name, which is also `Skill.id` in SkillDeck.
+    let records: [String: SkillUsageRecord]
+
+    /// Number of history files successfully read during this scan.
+    let scannedLogCount: Int
+}

--- a/Sources/SkillDeck/Models/SkillUsage.swift
+++ b/Sources/SkillDeck/Models/SkillUsage.swift
@@ -24,8 +24,8 @@ enum SkillUsageScanState: Equatable {
     /// SkillDeck is reading local history files in the background.
     case scanning
 
-    /// At least one Codex history file was readable, so a missing record means "not detected".
-    case available(scannedLogCount: Int)
+    /// At least one Codex history file is represented; failures are surfaced as incomplete coverage.
+    case available(scannedLogCount: Int, failedLogCount: Int)
 
     /// No readable Codex history files were found, so usage must be reported as unknown.
     case unavailable
@@ -36,6 +36,9 @@ struct SkillUsageScanResult: Equatable {
     /// Records are keyed by the skill directory name, which is also `Skill.id` in SkillDeck.
     let records: [String: SkillUsageRecord]
 
-    /// Number of history files successfully read during this scan.
+    /// Number of history files represented by fresh scan results or retained cache entries.
     let scannedLogCount: Int
+
+    /// Number of discovered history files that could not be read completely during this scan.
+    let failedLogCount: Int
 }

--- a/Sources/SkillDeck/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Sources/SkillDeck/Resources/Localizations/en.lproj/Localizable.strings
@@ -91,3 +91,26 @@
 
 "dashboard.language.menuLabel" = "Language";
 "dashboard.language.menuHelp" = "Switch app language";
+
+"usage.section.title" = "Usage (Codex)";
+"usage.scan.action" = "Scan History";
+"usage.notScanned" = "Usage history has not been scanned on this device";
+"usage.scanning" = "Scanning local Codex history...";
+"usage.detectedCalls" = "Detected uses";
+"usage.lastUsed" = "Last detected";
+"usage.neverDetected" = "No usage was detected in available Codex history";
+"usage.unavailable" = "Codex history is unavailable; previous usage is unknown";
+"usage.source" = "Source";
+"usage.source.codex" = "Local Codex history";
+"usage.caveat" = "Best-effort evidence only. Missing logs, other Agents, and project references are not included.";
+"usage.refresh.help" = "Rescan Codex usage history";
+
+"dashboard.delete.title" = "Delete Skill";
+"dashboard.delete.cancel" = "Cancel";
+"dashboard.delete.confirm" = "Delete";
+"dashboard.delete.message" = "Are you sure you want to delete \"%@\"? This removes the skill directory and all symlinks and cannot be undone.";
+"dashboard.delete.usage.notScanned" = "Codex usage history has not been scanned. Open this skill's detail page and scan history before using usage as deletion evidence.";
+"dashboard.delete.usage.scanning" = "Codex usage history is still being scanned; deletion safety cannot be assessed yet.";
+"dashboard.delete.usage.unknown" = "Codex usage history is unavailable, so previous usage is unknown. Deletion safety cannot be assessed.";
+"dashboard.delete.usage.detected" = "Codex history contains %d detected use(s), most recently %@. Confirm the skill is no longer needed before deleting it.";
+"dashboard.delete.usage.notDetected" = "No usage was detected in available Codex history, but this does not prove the skill is safe to delete; other Agents or projects may still reference it.";

--- a/Sources/SkillDeck/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Sources/SkillDeck/Resources/Localizations/en.lproj/Localizable.strings
@@ -104,3 +104,4 @@
 "usage.source.codex" = "Local Codex history";
 "usage.caveat" = "Best-effort evidence only. Missing logs, other Agents, and project references are not included.";
 "usage.refresh.help" = "Rescan Codex usage history";
+"usage.incomplete.help" = "Some Codex history files could not be read; usage statistics may be incomplete";

--- a/Sources/SkillDeck/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Sources/SkillDeck/Resources/Localizations/en.lproj/Localizable.strings
@@ -104,13 +104,3 @@
 "usage.source.codex" = "Local Codex history";
 "usage.caveat" = "Best-effort evidence only. Missing logs, other Agents, and project references are not included.";
 "usage.refresh.help" = "Rescan Codex usage history";
-
-"dashboard.delete.title" = "Delete Skill";
-"dashboard.delete.cancel" = "Cancel";
-"dashboard.delete.confirm" = "Delete";
-"dashboard.delete.message" = "Are you sure you want to delete \"%@\"? This removes the skill directory and all symlinks and cannot be undone.";
-"dashboard.delete.usage.notScanned" = "Codex usage history has not been scanned. Open this skill's detail page and scan history before using usage as deletion evidence.";
-"dashboard.delete.usage.scanning" = "Codex usage history is still being scanned; deletion safety cannot be assessed yet.";
-"dashboard.delete.usage.unknown" = "Codex usage history is unavailable, so previous usage is unknown. Deletion safety cannot be assessed.";
-"dashboard.delete.usage.detected" = "Codex history contains %d detected use(s), most recently %@. Confirm the skill is no longer needed before deleting it.";
-"dashboard.delete.usage.notDetected" = "No usage was detected in available Codex history, but this does not prove the skill is safe to delete; other Agents or projects may still reference it.";

--- a/Sources/SkillDeck/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Sources/SkillDeck/Resources/Localizations/en.lproj/Localizable.strings
@@ -92,7 +92,7 @@
 "dashboard.language.menuLabel" = "Language";
 "dashboard.language.menuHelp" = "Switch app language";
 
-"usage.section.title" = "Usage (Codex)";
+"usage.section.title" = "Usage";
 "usage.scan.action" = "Scan History";
 "usage.notScanned" = "Usage history has not been scanned on this device";
 "usage.scanning" = "Scanning local Codex history...";

--- a/Sources/SkillDeck/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Sources/SkillDeck/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -104,13 +104,3 @@
 "usage.source.codex" = "本地 Codex 历史记录";
 "usage.caveat" = "仅供参考：缺失的日志、其他 Agent 以及项目引用均未计入。";
 "usage.refresh.help" = "重新扫描 Codex 使用记录";
-
-"dashboard.delete.title" = "删除 Skill";
-"dashboard.delete.cancel" = "取消";
-"dashboard.delete.confirm" = "删除";
-"dashboard.delete.message" = "确定删除“%@”吗？这会移除 Skill 目录及所有符号链接，且无法撤销。";
-"dashboard.delete.usage.notScanned" = "尚未扫描 Codex 使用记录。如需参考使用情况判断删除风险，请先在该 Skill 的详情页扫描历史。";
-"dashboard.delete.usage.scanning" = "仍在扫描 Codex 使用记录，目前无法判断删除风险。";
-"dashboard.delete.usage.unknown" = "Codex 历史记录不可用，无法判断此前是否使用，也无法评估删除风险。";
-"dashboard.delete.usage.detected" = "Codex 历史中检测到 %d 次使用，最近一次为 %@。删除前请确认已不再需要。";
-"dashboard.delete.usage.notDetected" = "现有 Codex 历史中未检测到使用，但这不代表一定可以安全删除；其他 Agent 或项目仍可能引用它。";

--- a/Sources/SkillDeck/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Sources/SkillDeck/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -91,3 +91,26 @@
 
 "dashboard.language.menuLabel" = "语言";
 "dashboard.language.menuHelp" = "切换应用语言";
+
+"usage.section.title" = "使用情况（Codex）";
+"usage.scan.action" = "扫描历史";
+"usage.notScanned" = "尚未在此设备上扫描使用记录";
+"usage.scanning" = "正在扫描本地 Codex 历史记录…";
+"usage.detectedCalls" = "检测到的使用次数";
+"usage.lastUsed" = "最近检测时间";
+"usage.neverDetected" = "在现有 Codex 历史记录中未检测到使用";
+"usage.unavailable" = "Codex 历史记录不可用，无法判断此前是否使用";
+"usage.source" = "数据来源";
+"usage.source.codex" = "本地 Codex 历史记录";
+"usage.caveat" = "仅供参考：缺失的日志、其他 Agent 以及项目引用均未计入。";
+"usage.refresh.help" = "重新扫描 Codex 使用记录";
+
+"dashboard.delete.title" = "删除 Skill";
+"dashboard.delete.cancel" = "取消";
+"dashboard.delete.confirm" = "删除";
+"dashboard.delete.message" = "确定删除“%@”吗？这会移除 Skill 目录及所有符号链接，且无法撤销。";
+"dashboard.delete.usage.notScanned" = "尚未扫描 Codex 使用记录。如需参考使用情况判断删除风险，请先在该 Skill 的详情页扫描历史。";
+"dashboard.delete.usage.scanning" = "仍在扫描 Codex 使用记录，目前无法判断删除风险。";
+"dashboard.delete.usage.unknown" = "Codex 历史记录不可用，无法判断此前是否使用，也无法评估删除风险。";
+"dashboard.delete.usage.detected" = "Codex 历史中检测到 %d 次使用，最近一次为 %@。删除前请确认已不再需要。";
+"dashboard.delete.usage.notDetected" = "现有 Codex 历史中未检测到使用，但这不代表一定可以安全删除；其他 Agent 或项目仍可能引用它。";

--- a/Sources/SkillDeck/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Sources/SkillDeck/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -104,3 +104,4 @@
 "usage.source.codex" = "本地 Codex 历史记录";
 "usage.caveat" = "仅供参考：缺失的日志、其他 Agent 以及项目引用均未计入。";
 "usage.refresh.help" = "重新扫描 Codex 使用记录";
+"usage.incomplete.help" = "部分 Codex 历史记录无法读取，使用统计可能不完整";

--- a/Sources/SkillDeck/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Sources/SkillDeck/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -92,7 +92,7 @@
 "dashboard.language.menuLabel" = "语言";
 "dashboard.language.menuHelp" = "切换应用语言";
 
-"usage.section.title" = "使用情况（Codex）";
+"usage.section.title" = "使用情况";
 "usage.scan.action" = "扫描历史";
 "usage.notScanned" = "尚未在此设备上扫描使用记录";
 "usage.scanning" = "正在扫描本地 Codex 历史记录…";

--- a/Sources/SkillDeck/Services/CodexSkillUsageService.swift
+++ b/Sources/SkillDeck/Services/CodexSkillUsageService.swift
@@ -1,0 +1,354 @@
+import Foundation
+
+/// Recovers best-effort skill invocation evidence from Codex's local JSONL history.
+///
+/// Codex does not currently expose a stable public usage-statistics API. This adapter therefore
+/// treats a tool call that references a trusted local `SKILL.md` path as invocation evidence. The
+/// parser is deliberately isolated in one service so a future structured Codex event can replace
+/// this heuristic without changing the View or ViewModel layers.
+actor CodexSkillUsageService {
+    /// Codex currently keeps active and archived history under separate directory trees.
+    private let historyDirectories: [URL]
+    private let cacheURL: URL
+    private let fileManager: FileManager
+
+    /// Increment when the persisted cache schema or matching semantics change.
+    private static let cacheVersion = 1
+
+    /// Production initializer based on the current macOS user's home directory.
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) {
+        let codexDirectory = homeDirectory.appendingPathComponent(".codex", isDirectory: true)
+        let agentsDirectory = homeDirectory.appendingPathComponent(".agents", isDirectory: true)
+        self.historyDirectories = [
+            codexDirectory.appendingPathComponent("sessions", isDirectory: true),
+            codexDirectory.appendingPathComponent("archived_sessions", isDirectory: true),
+        ]
+        self.cacheURL = agentsDirectory.appendingPathComponent(".skilldeck-usage-cache.json")
+        self.fileManager = fileManager
+    }
+
+    /// Test initializer that avoids depending on the developer machine's real Codex history.
+    init(
+        historyDirectories: [URL],
+        cacheURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        self.historyDirectories = historyDirectories
+        self.cacheURL = cacheURL ?? fileManager.temporaryDirectory
+            .appendingPathComponent("SkillDeckUsageCache-\(UUID().uuidString).json")
+        self.fileManager = fileManager
+    }
+
+    /// Scan all readable JSONL files and build one index for every detected skill.
+    ///
+    /// Building a complete index in one pass is important because a user may click through many
+    /// skills. Re-reading every history file once per detail page would scale poorly.
+    func scan() -> SkillUsageScanResult {
+        var cache = loadCache()
+        var refreshedFiles: [String: CachedLogResult] = [:]
+        var changedLogs: [URL: LogFingerprint] = [:]
+        var scannedLogCount = 0
+
+        for logURL in historyLogURLs() {
+            guard let fingerprint = fingerprint(for: logURL) else {
+                continue
+            }
+
+            let cached = cache.files[logURL.path]
+            if let cached, cached.fingerprint == fingerprint {
+                // Unchanged files can be reused without touching their potentially large contents.
+                refreshedFiles[logURL.path] = cached
+                scannedLogCount += 1
+            } else {
+                changedLogs[logURL] = fingerprint
+            }
+        }
+
+        // macOS's native grep performs the broad byte search much faster than a Swift byte loop.
+        // Swift still parses every candidate as JSON and applies the trusted-path rules below.
+        if let scannedChanges = scanChangedLogs(changedLogs) {
+            refreshedFiles.merge(scannedChanges) { _, new in new }
+            scannedLogCount += scannedChanges.count
+        }
+
+        // Dropping cache entries for deleted logs prevents stale usage evidence from surviving forever.
+        cache.files = refreshedFiles
+        saveCache(cache)
+
+        var merged: [String: MutableUsageRecord] = [:]
+        for file in refreshedFiles.values {
+            for (skillID, fileRecord) in file.records {
+                var aggregate = merged[skillID] ?? MutableUsageRecord()
+                aggregate.detectedInvocationCount += fileRecord.detectedInvocationCount
+                if let timestamp = fileRecord.lastDetectedAt,
+                   aggregate.lastDetectedAt == nil || timestamp > aggregate.lastDetectedAt! {
+                    aggregate.lastDetectedAt = timestamp
+                }
+                merged[skillID] = aggregate
+            }
+        }
+
+        let records = merged.mapValues {
+            SkillUsageRecord(
+                detectedInvocationCount: $0.detectedInvocationCount,
+                lastDetectedAt: $0.lastDetectedAt
+            )
+        }
+        return SkillUsageScanResult(records: records, scannedLogCount: scannedLogCount)
+    }
+
+    /// Scan all changed logs with a two-stage fixed-string grep pipeline.
+    ///
+    /// Stage one keeps only `response_item` events. Stage two keeps only those mentioning
+    /// `SKILL.md`. This reduced roughly 1.8 GB of real-world history to a small candidate stream in
+    /// local benchmarks, while the subsequent Swift parser remains responsible for correctness.
+    private func scanChangedLogs(_ logs: [URL: LogFingerprint]) -> [String: CachedLogResult]? {
+        guard !logs.isEmpty else { return [:] }
+
+        let sortedURLs = logs.keys.sorted { $0.path < $1.path }
+        let responseItemGrep = Process()
+        responseItemGrep.executableURL = URL(fileURLWithPath: "/usr/bin/grep")
+        responseItemGrep.arguments = ["-H", "-F", "\"type\":\"response_item\""] + sortedURLs.map(\.path)
+
+        let skillMarkerGrep = Process()
+        skillMarkerGrep.executableURL = URL(fileURLWithPath: "/usr/bin/grep")
+        skillMarkerGrep.arguments = ["-F", "SKILL.md"]
+
+        let intermediatePipe = Pipe()
+        let outputPipe = Pipe()
+        responseItemGrep.standardOutput = intermediatePipe
+        skillMarkerGrep.standardInput = intermediatePipe
+        skillMarkerGrep.standardOutput = outputPipe
+        responseItemGrep.standardError = FileHandle.nullDevice
+        skillMarkerGrep.standardError = FileHandle.nullDevice
+
+        do {
+            // Start the consumer before the producer so neither side can block on a full pipe.
+            try skillMarkerGrep.run()
+            outputPipe.fileHandleForWriting.closeFile()
+
+            do {
+                try responseItemGrep.run()
+            } catch {
+                skillMarkerGrep.terminate()
+                return nil
+            }
+            intermediatePipe.fileHandleForWriting.closeFile()
+            intermediatePipe.fileHandleForReading.closeFile()
+
+            let output = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            responseItemGrep.waitUntilExit()
+            skillMarkerGrep.waitUntilExit()
+
+            // grep uses status 1 for "no matching lines", which is a successful empty result here.
+            guard [0, 1].contains(responseItemGrep.terminationStatus),
+                  [0, 1].contains(skillMarkerGrep.terminationStatus),
+                  let text = String(data: output, encoding: .utf8) else {
+                return nil
+            }
+
+            var perFileRecords = Dictionary(
+                uniqueKeysWithValues: sortedURLs.map { ($0.path, [String: MutableUsageRecord]()) }
+            )
+
+            text.enumerateLines { prefixedLine, _ in
+                // `grep -H` prefixes each candidate with `<absolute path>:`. Codex-generated
+                // rollout filenames do not contain colons, so the first delimiter is unambiguous.
+                guard let delimiter = prefixedLine.firstIndex(of: ":") else { return }
+                let path = String(prefixedLine[..<delimiter])
+                guard var records = perFileRecords[path] else { return }
+
+                let jsonStart = prefixedLine.index(after: delimiter)
+                let jsonLine = String(prefixedLine[jsonStart...])
+                self.consume(line: jsonLine, records: &records)
+                perFileRecords[path] = records
+            }
+
+            return perFileRecords.reduce(into: [:]) { result, entry in
+                guard let url = sortedURLs.first(where: { $0.path == entry.key }),
+                      let fingerprint = logs[url] else {
+                    return
+                }
+                result[entry.key] = CachedLogResult(
+                    fingerprint: fingerprint,
+                    records: entry.value.mapValues {
+                        SkillUsageRecord(
+                            detectedInvocationCount: $0.detectedInvocationCount,
+                            lastDetectedAt: $0.lastDetectedAt
+                        )
+                    }
+                )
+            }
+        } catch {
+            return nil
+        }
+    }
+
+    /// Enumerate active and archived Codex histories recursively.
+    private func historyLogURLs() -> [URL] {
+        var result: [URL] = []
+
+        for directory in historyDirectories where fileManager.fileExists(atPath: directory.path) {
+            guard let enumerator = fileManager.enumerator(
+                at: directory,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles, .skipsPackageDescendants]
+            ) else {
+                continue
+            }
+
+            for case let fileURL as URL in enumerator where fileURL.pathExtension == "jsonl" {
+                result.append(fileURL)
+            }
+        }
+
+        // Stable ordering makes tests deterministic and keeps future incremental caching possible.
+        return result.sorted { $0.path < $1.path }
+    }
+
+    /// Size plus modification time is a cheap and sufficient cache fingerprint for append-only logs.
+    private func fingerprint(for url: URL) -> LogFingerprint? {
+        guard let values = try? url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey]),
+              let fileSize = values.fileSize,
+              let modificationDate = values.contentModificationDate else {
+            return nil
+        }
+        return LogFingerprint(fileSize: UInt64(fileSize), modificationDate: modificationDate)
+    }
+
+    /// Parse one JSONL event and merge any trusted skill references into the index.
+    private func consume(line: String, records: inout [String: MutableUsageRecord]) {
+        // Most history lines do not mention a skill. This cheap filter avoids JSON parsing for them.
+        guard line.contains("SKILL.md"),
+              let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              object["type"] as? String == "response_item",
+              let payload = object["payload"] as? [String: Any],
+              let payloadType = payload["type"] as? String,
+              payloadType == "custom_tool_call" || payloadType == "function_call" else {
+            return
+        }
+
+        // Current Codex app logs use `input` for custom tool calls and `arguments` for function calls.
+        guard let toolInput = (payload["input"] as? String) ?? (payload["arguments"] as? String) else {
+            return
+        }
+
+        let skillIDs = trustedSkillIDs(in: toolInput)
+        guard !skillIDs.isEmpty else { return }
+
+        let timestamp = (object["timestamp"] as? String).flatMap(Self.parseTimestamp)
+        for skillID in skillIDs {
+            var record = records[skillID] ?? MutableUsageRecord()
+            record.detectedInvocationCount += 1
+            if let timestamp, record.lastDetectedAt == nil || timestamp > record.lastDetectedAt! {
+                record.lastDetectedAt = timestamp
+            }
+            records[skillID] = record
+        }
+    }
+
+    /// Extract skill directory names only from locations that Codex can legitimately load.
+    ///
+    /// A repository may also contain `skills/foo/SKILL.md`. Counting that path would create a false
+    /// positive while a developer merely edits a skill, so paths outside Codex's local skill stores
+    /// are intentionally ignored.
+    private func trustedSkillIDs(in toolInput: String) -> Set<String> {
+        let trustedMarkers = [
+            "/.agents/skills/",
+            "/.codex/skills/",
+            "/.codex/plugins/cache/",
+        ]
+
+        var result: Set<String> = []
+        var searchStart = toolInput.startIndex
+
+        while let suffixRange = toolInput.range(of: "/SKILL.md", range: searchStart..<toolInput.endIndex) {
+            let prefix = toolInput[..<suffixRange.lowerBound]
+
+            // The parent directory immediately before SKILL.md is the SkillDeck skill identifier.
+            guard let parentSlash = prefix.lastIndex(of: "/") else {
+                searchStart = suffixRange.upperBound
+                continue
+            }
+
+            let skillIDStart = toolInput.index(after: parentSlash)
+            let skillID = String(toolInput[skillIDStart..<suffixRange.lowerBound])
+
+            // Limit the trust check to the current command token. This prevents an earlier trusted
+            // path in the same shell command from making a later repository path look trusted.
+            let tokenStart = prefix.lastIndex { character in
+                character.isWhitespace || character == "\"" || character == "'" || character == ";"
+            }.map { toolInput.index(after: $0) } ?? toolInput.startIndex
+            let pathToken = String(toolInput[tokenStart..<suffixRange.upperBound])
+
+            if !skillID.isEmpty, trustedMarkers.contains(where: pathToken.contains) {
+                result.insert(skillID)
+            }
+
+            searchStart = suffixRange.upperBound
+        }
+
+        return result
+    }
+
+    /// Codex timestamps are ISO-8601 and commonly include fractional seconds.
+    private static func parseTimestamp(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: value) {
+            return date
+        }
+
+        let regular = ISO8601DateFormatter()
+        regular.formatOptions = [.withInternetDateTime]
+        return regular.date(from: value)
+    }
+
+    /// Read a versioned local cache. Invalid or old files safely fall back to a clean first scan.
+    private func loadCache() -> UsageCache {
+        guard let data = try? Data(contentsOf: cacheURL),
+              let decoded = try? JSONDecoder().decode(UsageCache.self, from: data),
+              decoded.version == Self.cacheVersion else {
+            return UsageCache(version: Self.cacheVersion, files: [:])
+        }
+        return decoded
+    }
+
+    /// Persist atomically so an interrupted app launch cannot leave a half-written cache.
+    private func saveCache(_ cache: UsageCache) {
+        let parent = cacheURL.deletingLastPathComponent()
+        do {
+            try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            try encoder.encode(cache).write(to: cacheURL, options: .atomic)
+        } catch {
+            // Usage remains available in memory even when cache persistence is not permitted.
+        }
+    }
+
+    /// Mutable accumulator kept private so the public model remains immutable.
+    private struct MutableUsageRecord {
+        var detectedInvocationCount = 0
+        var lastDetectedAt: Date?
+    }
+
+    private struct UsageCache: Codable {
+        let version: Int
+        var files: [String: CachedLogResult]
+    }
+
+    private struct CachedLogResult: Codable {
+        let fingerprint: LogFingerprint
+        let records: [String: SkillUsageRecord]
+    }
+
+    private struct LogFingerprint: Codable, Equatable {
+        let fileSize: UInt64
+        let modificationDate: Date
+    }
+}

--- a/Sources/SkillDeck/Services/CodexSkillUsageService.swift
+++ b/Sources/SkillDeck/Services/CodexSkillUsageService.swift
@@ -9,11 +9,12 @@ import Foundation
 actor CodexSkillUsageService {
     /// Codex currently keeps active and archived history under separate directory trees.
     private let historyDirectories: [URL]
-    private let cacheURL: URL
+    private let trustedHomeDirectory: URL
+    private let cacheURL: URL?
     private let fileManager: FileManager
 
     /// Increment when the persisted cache schema or matching semantics change.
-    private static let cacheVersion = 1
+    private static let cacheVersion = 2
 
     /// Production initializer based on the current macOS user's home directory.
     init(
@@ -26,6 +27,7 @@ actor CodexSkillUsageService {
             codexDirectory.appendingPathComponent("sessions", isDirectory: true),
             codexDirectory.appendingPathComponent("archived_sessions", isDirectory: true),
         ]
+        self.trustedHomeDirectory = homeDirectory.standardizedFileURL
         self.cacheURL = agentsDirectory.appendingPathComponent(".skilldeck-usage-cache.json")
         self.fileManager = fileManager
     }
@@ -33,12 +35,13 @@ actor CodexSkillUsageService {
     /// Test initializer that avoids depending on the developer machine's real Codex history.
     init(
         historyDirectories: [URL],
+        homeDirectory: URL,
         cacheURL: URL? = nil,
         fileManager: FileManager = .default
     ) {
         self.historyDirectories = historyDirectories
-        self.cacheURL = cacheURL ?? fileManager.temporaryDirectory
-            .appendingPathComponent("SkillDeckUsageCache-\(UUID().uuidString).json")
+        self.trustedHomeDirectory = homeDirectory.standardizedFileURL
+        self.cacheURL = cacheURL
         self.fileManager = fileManager
     }
 
@@ -50,10 +53,14 @@ actor CodexSkillUsageService {
         var cache = loadCache()
         var refreshedFiles: [String: CachedLogResult] = [:]
         var changedLogs: [URL: LogFingerprint] = [:]
-        var scannedLogCount = 0
+        var failedLogPaths: Set<String> = []
 
         for logURL in historyLogURLs() {
             guard let fingerprint = fingerprint(for: logURL) else {
+                failedLogPaths.insert(logURL.path)
+                if let cached = cache.files[logURL.path] {
+                    refreshedFiles[logURL.path] = cached
+                }
                 continue
             }
 
@@ -61,7 +68,6 @@ actor CodexSkillUsageService {
             if let cached, cached.fingerprint == fingerprint {
                 // Unchanged files can be reused without touching their potentially large contents.
                 refreshedFiles[logURL.path] = cached
-                scannedLogCount += 1
             } else {
                 changedLogs[logURL] = fingerprint
             }
@@ -69,9 +75,14 @@ actor CodexSkillUsageService {
 
         // macOS's native grep performs the broad byte search much faster than a Swift byte loop.
         // Swift still parses every candidate as JSON and applies the trusted-path rules below.
-        if let scannedChanges = scanChangedLogs(changedLogs) {
-            refreshedFiles.merge(scannedChanges) { _, new in new }
-            scannedLogCount += scannedChanges.count
+        let scannedChanges = scanChangedLogs(changedLogs)
+        refreshedFiles.merge(scannedChanges.files) { _, new in new }
+        failedLogPaths.formUnion(scannedChanges.failedPaths)
+        for path in scannedChanges.failedPaths {
+            // Keep the old fingerprint so a later refresh retries the failed file.
+            if let cached = cache.files[path] {
+                refreshedFiles[path] = cached
+            }
         }
 
         // Dropping cache entries for deleted logs prevents stale usage evidence from surviving forever.
@@ -97,7 +108,11 @@ actor CodexSkillUsageService {
                 lastDetectedAt: $0.lastDetectedAt
             )
         }
-        return SkillUsageScanResult(records: records, scannedLogCount: scannedLogCount)
+        return SkillUsageScanResult(
+            records: records,
+            scannedLogCount: refreshedFiles.count,
+            failedLogCount: failedLogPaths.count
+        )
     }
 
     /// Scan all changed logs with a two-stage fixed-string grep pipeline.
@@ -105,13 +120,72 @@ actor CodexSkillUsageService {
     /// Stage one keeps only `response_item` events. Stage two keeps only those mentioning
     /// `SKILL.md`. This reduced roughly 1.8 GB of real-world history to a small candidate stream in
     /// local benchmarks, while the subsequent Swift parser remains responsible for correctness.
-    private func scanChangedLogs(_ logs: [URL: LogFingerprint]) -> [String: CachedLogResult]? {
-        guard !logs.isEmpty else { return [:] }
+    private func scanChangedLogs(_ logs: [URL: LogFingerprint]) -> ChangedLogScanResult {
+        guard !logs.isEmpty else { return ChangedLogScanResult() }
 
         let sortedURLs = logs.keys.sorted { $0.path < $1.path }
+        let fingerprintsByPath = Dictionary(uniqueKeysWithValues: logs.map { ($0.key.path, $0.value) })
+        return scanChangedLogBatch(sortedURLs, fingerprintsByPath: fingerprintsByPath)
+    }
+
+    /// Keep the common path fast with one grep pipeline, then isolate exceptional files by bisection.
+    private func scanChangedLogBatch(
+        _ urls: [URL],
+        fingerprintsByPath: [String: LogFingerprint]
+    ) -> ChangedLogScanResult {
+        guard let text = candidateLines(in: urls) else {
+            guard urls.count > 1 else {
+                return ChangedLogScanResult(failedPaths: Set(urls.map(\.path)))
+            }
+
+            let midpoint = urls.count / 2
+            let left = scanChangedLogBatch(
+                Array(urls[..<midpoint]),
+                fingerprintsByPath: fingerprintsByPath
+            )
+            let right = scanChangedLogBatch(
+                Array(urls[midpoint...]),
+                fingerprintsByPath: fingerprintsByPath
+            )
+            return left.merging(right)
+        }
+
+        var perFileRecords = Dictionary(
+            uniqueKeysWithValues: urls.map { ($0.path, [String: MutableUsageRecord]()) }
+        )
+
+        text.enumerateLines { prefixedLine, _ in
+            // `grep -H` prefixes each candidate with `<absolute path>:`. Codex-generated rollout
+            // filenames do not contain colons, so the first delimiter is unambiguous.
+            guard let delimiter = prefixedLine.firstIndex(of: ":") else { return }
+            let path = String(prefixedLine[..<delimiter])
+            guard var records = perFileRecords[path] else { return }
+
+            let jsonStart = prefixedLine.index(after: delimiter)
+            let jsonLine = String(prefixedLine[jsonStart...])
+            self.consume(line: jsonLine, records: &records)
+            perFileRecords[path] = records
+        }
+
+        let files = perFileRecords.reduce(into: [String: CachedLogResult]()) { result, entry in
+            guard let fingerprint = fingerprintsByPath[entry.key] else { return }
+            result[entry.key] = CachedLogResult(
+                fingerprint: fingerprint,
+                records: entry.value.mapValues {
+                    SkillUsageRecord(
+                        detectedInvocationCount: $0.detectedInvocationCount,
+                        lastDetectedAt: $0.lastDetectedAt
+                    )
+                }
+            )
+        }
+        return ChangedLogScanResult(files: files)
+    }
+
+    private func candidateLines(in urls: [URL]) -> String? {
         let responseItemGrep = Process()
         responseItemGrep.executableURL = URL(fileURLWithPath: "/usr/bin/grep")
-        responseItemGrep.arguments = ["-H", "-F", "\"type\":\"response_item\""] + sortedURLs.map(\.path)
+        responseItemGrep.arguments = ["-H", "-F", "\"type\":\"response_item\""] + urls.map(\.path)
 
         let skillMarkerGrep = Process()
         skillMarkerGrep.executableURL = URL(fileURLWithPath: "/usr/bin/grep")
@@ -149,39 +223,7 @@ actor CodexSkillUsageService {
                   let text = String(data: output, encoding: .utf8) else {
                 return nil
             }
-
-            var perFileRecords = Dictionary(
-                uniqueKeysWithValues: sortedURLs.map { ($0.path, [String: MutableUsageRecord]()) }
-            )
-
-            text.enumerateLines { prefixedLine, _ in
-                // `grep -H` prefixes each candidate with `<absolute path>:`. Codex-generated
-                // rollout filenames do not contain colons, so the first delimiter is unambiguous.
-                guard let delimiter = prefixedLine.firstIndex(of: ":") else { return }
-                let path = String(prefixedLine[..<delimiter])
-                guard var records = perFileRecords[path] else { return }
-
-                let jsonStart = prefixedLine.index(after: delimiter)
-                let jsonLine = String(prefixedLine[jsonStart...])
-                self.consume(line: jsonLine, records: &records)
-                perFileRecords[path] = records
-            }
-
-            return perFileRecords.reduce(into: [:]) { result, entry in
-                guard let url = sortedURLs.first(where: { $0.path == entry.key }),
-                      let fingerprint = logs[url] else {
-                    return
-                }
-                result[entry.key] = CachedLogResult(
-                    fingerprint: fingerprint,
-                    records: entry.value.mapValues {
-                        SkillUsageRecord(
-                            detectedInvocationCount: $0.detectedInvocationCount,
-                            lastDetectedAt: $0.lastDetectedAt
-                        )
-                    }
-                )
-            }
+            return text
         } catch {
             return nil
         }
@@ -257,26 +299,11 @@ actor CodexSkillUsageService {
     /// positive while a developer merely edits a skill, so paths outside Codex's local skill stores
     /// are intentionally ignored.
     private func trustedSkillIDs(in toolInput: String) -> Set<String> {
-        let trustedMarkers = [
-            "/.agents/skills/",
-            "/.codex/skills/",
-            "/.codex/plugins/cache/",
-        ]
-
         var result: Set<String> = []
         var searchStart = toolInput.startIndex
 
         while let suffixRange = toolInput.range(of: "/SKILL.md", range: searchStart..<toolInput.endIndex) {
             let prefix = toolInput[..<suffixRange.lowerBound]
-
-            // The parent directory immediately before SKILL.md is the SkillDeck skill identifier.
-            guard let parentSlash = prefix.lastIndex(of: "/") else {
-                searchStart = suffixRange.upperBound
-                continue
-            }
-
-            let skillIDStart = toolInput.index(after: parentSlash)
-            let skillID = String(toolInput[skillIDStart..<suffixRange.lowerBound])
 
             // Limit the trust check to the current command token. This prevents an earlier trusted
             // path in the same shell command from making a later repository path look trusted.
@@ -285,7 +312,7 @@ actor CodexSkillUsageService {
             }.map { toolInput.index(after: $0) } ?? toolInput.startIndex
             let pathToken = String(toolInput[tokenStart..<suffixRange.upperBound])
 
-            if !skillID.isEmpty, trustedMarkers.contains(where: pathToken.contains) {
+            if let skillID = trustedSkillID(at: pathToken) {
                 result.insert(skillID)
             }
 
@@ -293,6 +320,56 @@ actor CodexSkillUsageService {
         }
 
         return result
+    }
+
+    /// Validate the complete standardized path against supported stores inside the configured home.
+    private func trustedSkillID(at pathToken: String) -> String? {
+        let expandedPath: String
+        if pathToken.hasPrefix("~/") {
+            expandedPath = trustedHomeDirectory
+                .appendingPathComponent(String(pathToken.dropFirst(2)))
+                .path
+        } else {
+            expandedPath = pathToken
+        }
+
+        guard expandedPath.hasPrefix("/") else { return nil }
+        let pathComponents = URL(fileURLWithPath: expandedPath).standardizedFileURL.pathComponents
+        let homeComponents = trustedHomeDirectory.pathComponents
+        guard pathComponents.starts(with: homeComponents) else { return nil }
+
+        let relative = Array(pathComponents.dropFirst(homeComponents.count))
+        guard relative.last == "SKILL.md" else { return nil }
+
+        if relative.count == 4,
+           relative[0] == ".agents",
+           relative[1] == "skills" {
+            return relative[2]
+        }
+
+        if relative.count == 4,
+           relative[0] == ".codex",
+           relative[1] == "skills",
+           relative[2] != ".system" {
+            return relative[2]
+        }
+
+        if relative.count == 5,
+           relative[0] == ".codex",
+           relative[1] == "skills",
+           relative[2] == ".system" {
+            return relative[3]
+        }
+
+        if relative.count >= 7,
+           relative[0] == ".codex",
+           relative[1] == "plugins",
+           relative[2] == "cache",
+           relative[relative.count - 3] == "skills" {
+            return relative[relative.count - 2]
+        }
+
+        return nil
     }
 
     /// Codex timestamps are ISO-8601 and commonly include fractional seconds.
@@ -310,7 +387,8 @@ actor CodexSkillUsageService {
 
     /// Read a versioned local cache. Invalid or old files safely fall back to a clean first scan.
     private func loadCache() -> UsageCache {
-        guard let data = try? Data(contentsOf: cacheURL),
+        guard let cacheURL,
+              let data = try? Data(contentsOf: cacheURL),
               let decoded = try? JSONDecoder().decode(UsageCache.self, from: data),
               decoded.version == Self.cacheVersion else {
             return UsageCache(version: Self.cacheVersion, files: [:])
@@ -320,6 +398,7 @@ actor CodexSkillUsageService {
 
     /// Persist atomically so an interrupted app launch cannot leave a half-written cache.
     private func saveCache(_ cache: UsageCache) {
+        guard let cacheURL else { return }
         let parent = cacheURL.deletingLastPathComponent()
         do {
             try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
@@ -345,6 +424,20 @@ actor CodexSkillUsageService {
     private struct CachedLogResult: Codable {
         let fingerprint: LogFingerprint
         let records: [String: SkillUsageRecord]
+    }
+
+    private struct ChangedLogScanResult {
+        var files: [String: CachedLogResult] = [:]
+        var failedPaths: Set<String> = []
+
+        func merging(_ other: ChangedLogScanResult) -> ChangedLogScanResult {
+            var mergedFiles = files
+            mergedFiles.merge(other.files) { _, new in new }
+            return ChangedLogScanResult(
+                files: mergedFiles,
+                failedPaths: failedPaths.union(other.failedPaths)
+            )
+        }
     }
 
     private struct LogFingerprint: Codable, Equatable {

--- a/Sources/SkillDeck/Services/SkillManager.swift
+++ b/Sources/SkillDeck/Services/SkillManager.swift
@@ -102,6 +102,15 @@ final class SkillManager {
     /// so the UI can still generate GitHub compare URLs after a refresh.
     private var cachedRemoteCommitHashes: [String: String] = [:]
 
+    /// Best-effort Codex invocation evidence, indexed by `Skill.id`.
+    ///
+    /// Keeping the index in the shared manager lets the detail page and delete confirmation reuse
+    /// one history scan instead of performing duplicate filesystem work.
+    var codexSkillUsageRecords: [String: SkillUsageRecord] = [:]
+
+    /// Current coverage state for Codex's local history scan.
+    var codexSkillUsageScanState: SkillUsageScanState = .notScanned
+
     // MARK: - App Update State (application self-update status)
 
     /// Latest release info (nil means no update available or not yet checked)
@@ -135,6 +144,9 @@ final class SkillManager {
     /// Stored in ~/.agents/.skilldeck-cache.json, doesn't pollute npx skills' lock file format
     private let commitHashCache = CommitHashCache()
 
+    /// Agent-specific adapter for reconstructing historical Codex skill invocations.
+    private let codexSkillUsageService: CodexSkillUsageService
+
     private let translationService = TranslationService()
 
     private static let dontShowTranslationPackPromptKey = "translationPackPromptDontShowAgain"
@@ -152,8 +164,38 @@ final class SkillManager {
 
     // MARK: - Initialization
 
-    init() {
+    init(codexSkillUsageService: CodexSkillUsageService = CodexSkillUsageService()) {
+        self.codexSkillUsageService = codexSkillUsageService
         setupFileWatcher()
+    }
+
+    /// Load the Codex usage index once, or rebuild it when the user explicitly refreshes.
+    ///
+    /// The service actor performs file I/O away from the main actor. Only the small final result is
+    /// assigned back to observable UI state on the main actor.
+    func loadCodexSkillUsage(forceRefresh: Bool = false) async {
+        if codexSkillUsageScanState == .scanning {
+            return
+        }
+
+        if !forceRefresh, case .available = codexSkillUsageScanState {
+            return
+        }
+
+        codexSkillUsageScanState = .scanning
+        let result = await codexSkillUsageService.scan()
+        codexSkillUsageRecords = result.records
+
+        if result.scannedLogCount > 0 {
+            codexSkillUsageScanState = .available(scannedLogCount: result.scannedLogCount)
+        } else {
+            codexSkillUsageScanState = .unavailable
+        }
+    }
+
+    /// Return usage evidence for one skill after the shared index has been loaded.
+    func codexSkillUsage(for skillID: String) -> SkillUsageRecord? {
+        codexSkillUsageRecords[skillID]
     }
 
     /// Translate a short English paragraph into Simplified Chinese (zh-CN).

--- a/Sources/SkillDeck/Services/SkillManager.swift
+++ b/Sources/SkillDeck/Services/SkillManager.swift
@@ -187,7 +187,10 @@ final class SkillManager {
         codexSkillUsageRecords = result.records
 
         if result.scannedLogCount > 0 {
-            codexSkillUsageScanState = .available(scannedLogCount: result.scannedLogCount)
+            codexSkillUsageScanState = .available(
+                scannedLogCount: result.scannedLogCount,
+                failedLogCount: result.failedLogCount
+            )
         } else {
             codexSkillUsageScanState = .unavailable
         }

--- a/Sources/SkillDeck/Services/SkillManager.swift
+++ b/Sources/SkillDeck/Services/SkillManager.swift
@@ -104,8 +104,8 @@ final class SkillManager {
 
     /// Best-effort Codex invocation evidence, indexed by `Skill.id`.
     ///
-    /// Keeping the index in the shared manager lets the detail page and delete confirmation reuse
-    /// one history scan instead of performing duplicate filesystem work.
+    /// Keeping the index in the shared manager lets skill detail pages reuse one history scan
+    /// instead of performing duplicate filesystem work.
     var codexSkillUsageRecords: [String: SkillUsageRecord] = [:]
 
     /// Current coverage state for Codex's local history scan.

--- a/Sources/SkillDeck/Utilities/Localization/L10nKeys.swift
+++ b/Sources/SkillDeck/Utilities/Localization/L10nKeys.swift
@@ -102,6 +102,7 @@ enum L10nKeys {
     static let usageSourceCodex = "usage.source.codex"
     static let usageCaveat = "usage.caveat"
     static let usageRefreshHelp = "usage.refresh.help"
+    static let usageIncompleteHelp = "usage.incomplete.help"
 
     static let allKeys: [String] = [
         appName,
@@ -188,5 +189,6 @@ enum L10nKeys {
         usageSourceCodex,
         usageCaveat,
         usageRefreshHelp,
+        usageIncompleteHelp,
     ]
 }

--- a/Sources/SkillDeck/Utilities/Localization/L10nKeys.swift
+++ b/Sources/SkillDeck/Utilities/Localization/L10nKeys.swift
@@ -90,6 +90,29 @@ enum L10nKeys {
     static let dashboardLanguageMenuLabel = "dashboard.language.menuLabel"
     static let dashboardLanguageMenuHelp = "dashboard.language.menuHelp"
 
+    static let usageSectionTitle = "usage.section.title"
+    static let usageScanAction = "usage.scan.action"
+    static let usageNotScanned = "usage.notScanned"
+    static let usageScanning = "usage.scanning"
+    static let usageDetectedCalls = "usage.detectedCalls"
+    static let usageLastUsed = "usage.lastUsed"
+    static let usageNeverDetected = "usage.neverDetected"
+    static let usageUnavailable = "usage.unavailable"
+    static let usageSource = "usage.source"
+    static let usageSourceCodex = "usage.source.codex"
+    static let usageCaveat = "usage.caveat"
+    static let usageRefreshHelp = "usage.refresh.help"
+
+    static let dashboardDeleteTitle = "dashboard.delete.title"
+    static let dashboardDeleteCancel = "dashboard.delete.cancel"
+    static let dashboardDeleteConfirm = "dashboard.delete.confirm"
+    static let dashboardDeleteMessage = "dashboard.delete.message"
+    static let dashboardDeleteUsageNotScanned = "dashboard.delete.usage.notScanned"
+    static let dashboardDeleteUsageScanning = "dashboard.delete.usage.scanning"
+    static let dashboardDeleteUsageUnknown = "dashboard.delete.usage.unknown"
+    static let dashboardDeleteUsageDetected = "dashboard.delete.usage.detected"
+    static let dashboardDeleteUsageNotDetected = "dashboard.delete.usage.notDetected"
+
     static let allKeys: [String] = [
         appName,
         settingsTabGeneral,
@@ -163,5 +186,26 @@ enum L10nKeys {
         emptySelectSkillSubtitleClawHub,
         dashboardLanguageMenuLabel,
         dashboardLanguageMenuHelp,
+        usageSectionTitle,
+        usageScanAction,
+        usageNotScanned,
+        usageScanning,
+        usageDetectedCalls,
+        usageLastUsed,
+        usageNeverDetected,
+        usageUnavailable,
+        usageSource,
+        usageSourceCodex,
+        usageCaveat,
+        usageRefreshHelp,
+        dashboardDeleteTitle,
+        dashboardDeleteCancel,
+        dashboardDeleteConfirm,
+        dashboardDeleteMessage,
+        dashboardDeleteUsageNotScanned,
+        dashboardDeleteUsageScanning,
+        dashboardDeleteUsageUnknown,
+        dashboardDeleteUsageDetected,
+        dashboardDeleteUsageNotDetected,
     ]
 }

--- a/Sources/SkillDeck/Utilities/Localization/L10nKeys.swift
+++ b/Sources/SkillDeck/Utilities/Localization/L10nKeys.swift
@@ -103,16 +103,6 @@ enum L10nKeys {
     static let usageCaveat = "usage.caveat"
     static let usageRefreshHelp = "usage.refresh.help"
 
-    static let dashboardDeleteTitle = "dashboard.delete.title"
-    static let dashboardDeleteCancel = "dashboard.delete.cancel"
-    static let dashboardDeleteConfirm = "dashboard.delete.confirm"
-    static let dashboardDeleteMessage = "dashboard.delete.message"
-    static let dashboardDeleteUsageNotScanned = "dashboard.delete.usage.notScanned"
-    static let dashboardDeleteUsageScanning = "dashboard.delete.usage.scanning"
-    static let dashboardDeleteUsageUnknown = "dashboard.delete.usage.unknown"
-    static let dashboardDeleteUsageDetected = "dashboard.delete.usage.detected"
-    static let dashboardDeleteUsageNotDetected = "dashboard.delete.usage.notDetected"
-
     static let allKeys: [String] = [
         appName,
         settingsTabGeneral,
@@ -198,14 +188,5 @@ enum L10nKeys {
         usageSourceCodex,
         usageCaveat,
         usageRefreshHelp,
-        dashboardDeleteTitle,
-        dashboardDeleteCancel,
-        dashboardDeleteConfirm,
-        dashboardDeleteMessage,
-        dashboardDeleteUsageNotScanned,
-        dashboardDeleteUsageScanning,
-        dashboardDeleteUsageUnknown,
-        dashboardDeleteUsageDetected,
-        dashboardDeleteUsageNotDetected,
     ]
 }

--- a/Sources/SkillDeck/Views/Dashboard/DashboardView.swift
+++ b/Sources/SkillDeck/Views/Dashboard/DashboardView.swift
@@ -131,16 +131,16 @@ struct DashboardView: View {
         }
         // Delete confirmation dialog
         // .alert similar to Android's AlertDialog or Web's confirm()
-        .alert(localized(L10nKeys.dashboardDeleteTitle), isPresented: $viewModel.showDeleteConfirmation) {
-            Button(localized(L10nKeys.dashboardDeleteCancel), role: .cancel) {
+        .alert("Delete Skill", isPresented: $viewModel.showDeleteConfirmation) {
+            Button("Cancel", role: .cancel) {
                 viewModel.cancelDelete()
             }
-            Button(localized(L10nKeys.dashboardDeleteConfirm), role: .destructive) {
+            Button("Delete", role: .destructive) {
                 Task { await viewModel.confirmDelete() }
             }
         } message: {
             if let skill = viewModel.skillToDelete {
-                Text(deleteConfirmationMessage(for: skill))
+                Text("Are you sure you want to delete \"\(skill.displayName)\"? This will remove the skill directory and all symlinks. This action cannot be undone.")
             }
         }
         // Error message
@@ -181,47 +181,4 @@ struct DashboardView: View {
         }
     }
 
-    /// Build deletion guidance from the best usage evidence currently available.
-    ///
-    /// A zero count never says "safe" because Codex history can be incomplete and SkillDeck does
-    /// not yet inspect references from other Agents or project-level instruction files.
-    private func deleteConfirmationMessage(for skill: Skill) -> String {
-        let base = String(
-            format: localized(L10nKeys.dashboardDeleteMessage),
-            skill.displayName
-        )
-
-        let usageMessage: String
-        switch skillManager.codexSkillUsageScanState {
-        case .notScanned:
-            usageMessage = localized(L10nKeys.dashboardDeleteUsageNotScanned)
-
-        case .scanning:
-            usageMessage = localized(L10nKeys.dashboardDeleteUsageScanning)
-
-        case .unavailable:
-            usageMessage = localized(L10nKeys.dashboardDeleteUsageUnknown)
-
-        case .available:
-            if let record = skillManager.codexSkillUsage(for: skill.id) {
-                let lastUsed = record.lastDetectedAt?.formatted(
-                    Date.FormatStyle(date: .abbreviated, time: .shortened)
-                        .locale(locale)
-                ) ?? "—"
-                usageMessage = String(
-                    format: localized(L10nKeys.dashboardDeleteUsageDetected),
-                    record.detectedInvocationCount,
-                    lastUsed
-                )
-            } else {
-                usageMessage = localized(L10nKeys.dashboardDeleteUsageNotDetected)
-            }
-        }
-
-        return "\(base)\n\n\(usageMessage)"
-    }
-
-    private func localized(_ key: String) -> String {
-        L10n.string(key, bundle: localizationBundle, locale: locale)
-    }
 }

--- a/Sources/SkillDeck/Views/Dashboard/DashboardView.swift
+++ b/Sources/SkillDeck/Views/Dashboard/DashboardView.swift
@@ -131,16 +131,16 @@ struct DashboardView: View {
         }
         // Delete confirmation dialog
         // .alert similar to Android's AlertDialog or Web's confirm()
-        .alert("Delete Skill", isPresented: $viewModel.showDeleteConfirmation) {
-            Button("Cancel", role: .cancel) {
+        .alert(localized(L10nKeys.dashboardDeleteTitle), isPresented: $viewModel.showDeleteConfirmation) {
+            Button(localized(L10nKeys.dashboardDeleteCancel), role: .cancel) {
                 viewModel.cancelDelete()
             }
-            Button("Delete", role: .destructive) {
+            Button(localized(L10nKeys.dashboardDeleteConfirm), role: .destructive) {
                 Task { await viewModel.confirmDelete() }
             }
         } message: {
             if let skill = viewModel.skillToDelete {
-                Text("Are you sure you want to delete \"\(skill.displayName)\"? This will remove the skill directory and all symlinks. This action cannot be undone.")
+                Text(deleteConfirmationMessage(for: skill))
             }
         }
         // Error message
@@ -179,5 +179,49 @@ struct DashboardView: View {
         case .simplifiedChinese:
             return "中"
         }
+    }
+
+    /// Build deletion guidance from the best usage evidence currently available.
+    ///
+    /// A zero count never says "safe" because Codex history can be incomplete and SkillDeck does
+    /// not yet inspect references from other Agents or project-level instruction files.
+    private func deleteConfirmationMessage(for skill: Skill) -> String {
+        let base = String(
+            format: localized(L10nKeys.dashboardDeleteMessage),
+            skill.displayName
+        )
+
+        let usageMessage: String
+        switch skillManager.codexSkillUsageScanState {
+        case .notScanned:
+            usageMessage = localized(L10nKeys.dashboardDeleteUsageNotScanned)
+
+        case .scanning:
+            usageMessage = localized(L10nKeys.dashboardDeleteUsageScanning)
+
+        case .unavailable:
+            usageMessage = localized(L10nKeys.dashboardDeleteUsageUnknown)
+
+        case .available:
+            if let record = skillManager.codexSkillUsage(for: skill.id) {
+                let lastUsed = record.lastDetectedAt?.formatted(
+                    Date.FormatStyle(date: .abbreviated, time: .shortened)
+                        .locale(locale)
+                ) ?? "—"
+                usageMessage = String(
+                    format: localized(L10nKeys.dashboardDeleteUsageDetected),
+                    record.detectedInvocationCount,
+                    lastUsed
+                )
+            } else {
+                usageMessage = localized(L10nKeys.dashboardDeleteUsageNotDetected)
+            }
+        }
+
+        return "\(base)\n\n\(usageMessage)"
+    }
+
+    private func localized(_ key: String) -> String {
+        L10n.string(key, bundle: localizationBundle, locale: locale)
     }
 }

--- a/Sources/SkillDeck/Views/Detail/SkillDetailView.swift
+++ b/Sources/SkillDeck/Views/Detail/SkillDetailView.swift
@@ -14,6 +14,7 @@ struct SkillDetailView: View {
     @Bindable var viewModel: SkillDetailViewModel
     @Environment(SkillManager.self) private var skillManager
     @Environment(\.locale) private var locale
+    @Environment(\.localizationBundle) private var localizationBundle
 
     @AppStorage(LanguageSettings.appLanguageKey) private var appLanguageRaw: String = LanguageSettings.defaultLanguage.rawValue
 
@@ -39,6 +40,12 @@ struct SkillDetailView: View {
                     } else {
                         linkToRepoSection(skill)
                     }
+
+                    Divider()
+
+                    // Best-effort historical usage recovered from local Codex session logs.
+                    // Keep this above the long Agent list so first-time users can discover it.
+                    usageSection(skill)
 
                     Divider()
 
@@ -195,6 +202,97 @@ struct SkillDetailView: View {
         }
     }
 
+    /// Codex usage evidence section.
+    ///
+    /// The UI says "detected" rather than "total" because local history may be incomplete. This
+    /// distinction is important for deletion safety: zero matches is useful evidence, but it is not
+    /// proof that the skill is unreferenced by another Agent or project configuration.
+    private func usageSection(_ skill: Skill) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                LText(key: L10nKeys.usageSectionTitle)
+                    .appFont(.headline)
+
+                Spacer()
+
+                if skillManager.codexSkillUsageScanState == .notScanned {
+                    Button(localized(L10nKeys.usageScanAction)) {
+                        Task { await skillManager.loadCodexSkillUsage() }
+                    }
+                    .controlSize(.small)
+                } else if skillManager.codexSkillUsageScanState != .scanning {
+                    Button {
+                        Task { await skillManager.loadCodexSkillUsage(forceRefresh: true) }
+                    } label: {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                    }
+                    .controlSize(.small)
+                    .help(localized(L10nKeys.usageRefreshHelp))
+                }
+            }
+
+            switch skillManager.codexSkillUsageScanState {
+            case .notScanned:
+                Label(localized(L10nKeys.usageNotScanned), systemImage: "clock.arrow.circlepath")
+                    .appFont(.subheadline)
+                    .foregroundStyle(.secondary)
+
+            case .scanning:
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    LText(key: L10nKeys.usageScanning)
+                        .appFont(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+            case .unavailable:
+                Label(localized(L10nKeys.usageUnavailable), systemImage: "questionmark.circle")
+                    .appFont(.subheadline)
+                    .foregroundStyle(.secondary)
+
+            case .available:
+                if let record = skillManager.codexSkillUsage(for: skill.id) {
+                    Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 6) {
+                        GridRow {
+                            LText(key: L10nKeys.usageDetectedCalls)
+                                .foregroundStyle(.secondary)
+                            Text(record.detectedInvocationCount.formatted())
+                        }
+
+                        GridRow {
+                            LText(key: L10nKeys.usageLastUsed)
+                                .foregroundStyle(.secondary)
+                            if let lastDetectedAt = record.lastDetectedAt {
+                                Text(lastDetectedAt.formatted(
+                                    Date.FormatStyle(date: .abbreviated, time: .shortened)
+                                        .locale(locale)
+                                ))
+                            } else {
+                                Text("—")
+                            }
+                        }
+
+                        GridRow {
+                            LText(key: L10nKeys.usageSource)
+                                .foregroundStyle(.secondary)
+                            LText(key: L10nKeys.usageSourceCodex)
+                        }
+                    }
+                    .appFont(.subheadline)
+                } else {
+                    Label(localized(L10nKeys.usageNeverDetected), systemImage: "clock.badge.questionmark")
+                        .appFont(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                LText(key: L10nKeys.usageCaveat)
+                    .appFont(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
     /// Markdown body section
     @ViewBuilder
     private func markdownSection(_ skill: Skill) -> some View {
@@ -216,6 +314,11 @@ struct SkillDetailView: View {
                     .cornerRadius(8)
             }
         }
+    }
+
+    /// Short alias that keeps localized call sites readable inside deeply nested ViewBuilders.
+    private func localized(_ key: String) -> String {
+        L10n.string(key, bundle: localizationBundle, locale: locale)
     }
 
     /// Manual repository linking section — displayed when skill has no lockEntry

--- a/Sources/SkillDeck/Views/Detail/SkillDetailView.swift
+++ b/Sources/SkillDeck/Views/Detail/SkillDetailView.swift
@@ -202,16 +202,24 @@ struct SkillDetailView: View {
         }
     }
 
-    /// Codex usage evidence section.
+    /// Usage evidence grouped by Agent. Codex is the first supported provider.
     ///
     /// The UI says "detected" rather than "total" because local history may be incomplete. This
     /// distinction is important for deletion safety: zero matches is useful evidence, but it is not
     /// proof that the skill is unreferenced by another Agent or project configuration.
     private func usageSection(_ skill: Skill) -> some View {
         VStack(alignment: .leading, spacing: 8) {
+            LText(key: L10nKeys.usageSectionTitle)
+                .appFont(.headline)
+
             HStack {
-                LText(key: L10nKeys.usageSectionTitle)
-                    .appFont(.headline)
+                Image(systemName: AgentType.codex.iconName)
+                    .foregroundStyle(Constants.AgentColors.color(for: .codex))
+                    .frame(width: 20)
+
+                Text(AgentType.codex.displayName)
+                    .appFont(.subheadline)
+                    .fontWeight(.semibold)
 
                 Spacer()
 
@@ -231,65 +239,68 @@ struct SkillDetailView: View {
                 }
             }
 
-            switch skillManager.codexSkillUsageScanState {
-            case .notScanned:
-                Label(localized(L10nKeys.usageNotScanned), systemImage: "clock.arrow.circlepath")
-                    .appFont(.subheadline)
-                    .foregroundStyle(.secondary)
-
-            case .scanning:
-                HStack(spacing: 8) {
-                    ProgressView()
-                        .controlSize(.small)
-                    LText(key: L10nKeys.usageScanning)
+            Group {
+                switch skillManager.codexSkillUsageScanState {
+                case .notScanned:
+                    Label(localized(L10nKeys.usageNotScanned), systemImage: "clock.arrow.circlepath")
                         .appFont(.subheadline)
                         .foregroundStyle(.secondary)
-                }
 
-            case .unavailable:
-                Label(localized(L10nKeys.usageUnavailable), systemImage: "questionmark.circle")
-                    .appFont(.subheadline)
-                    .foregroundStyle(.secondary)
+                case .scanning:
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        LText(key: L10nKeys.usageScanning)
+                            .appFont(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
 
-            case .available:
-                if let record = skillManager.codexSkillUsage(for: skill.id) {
-                    Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 6) {
-                        GridRow {
-                            LText(key: L10nKeys.usageDetectedCalls)
-                                .foregroundStyle(.secondary)
-                            Text(record.detectedInvocationCount.formatted())
-                        }
+                case .unavailable:
+                    Label(localized(L10nKeys.usageUnavailable), systemImage: "questionmark.circle")
+                        .appFont(.subheadline)
+                        .foregroundStyle(.secondary)
 
-                        GridRow {
-                            LText(key: L10nKeys.usageLastUsed)
-                                .foregroundStyle(.secondary)
-                            if let lastDetectedAt = record.lastDetectedAt {
-                                Text(lastDetectedAt.formatted(
-                                    Date.FormatStyle(date: .abbreviated, time: .shortened)
-                                        .locale(locale)
-                                ))
-                            } else {
-                                Text("—")
+                case .available:
+                    if let record = skillManager.codexSkillUsage(for: skill.id) {
+                        Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 6) {
+                            GridRow {
+                                LText(key: L10nKeys.usageDetectedCalls)
+                                    .foregroundStyle(.secondary)
+                                Text(record.detectedInvocationCount.formatted())
+                            }
+
+                            GridRow {
+                                LText(key: L10nKeys.usageLastUsed)
+                                    .foregroundStyle(.secondary)
+                                if let lastDetectedAt = record.lastDetectedAt {
+                                    Text(lastDetectedAt.formatted(
+                                        Date.FormatStyle(date: .abbreviated, time: .shortened)
+                                            .locale(locale)
+                                    ))
+                                } else {
+                                    Text("—")
+                                }
+                            }
+
+                            GridRow {
+                                LText(key: L10nKeys.usageSource)
+                                    .foregroundStyle(.secondary)
+                                LText(key: L10nKeys.usageSourceCodex)
                             }
                         }
-
-                        GridRow {
-                            LText(key: L10nKeys.usageSource)
-                                .foregroundStyle(.secondary)
-                            LText(key: L10nKeys.usageSourceCodex)
-                        }
-                    }
-                    .appFont(.subheadline)
-                } else {
-                    Label(localized(L10nKeys.usageNeverDetected), systemImage: "clock.badge.questionmark")
                         .appFont(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
+                    } else {
+                        Label(localized(L10nKeys.usageNeverDetected), systemImage: "clock.badge.questionmark")
+                            .appFont(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
 
-                LText(key: L10nKeys.usageCaveat)
-                    .appFont(.caption)
-                    .foregroundStyle(.tertiary)
+                    LText(key: L10nKeys.usageCaveat)
+                        .appFont(.caption)
+                        .foregroundStyle(.tertiary)
+                }
             }
+            .padding(.leading, 28)
         }
     }
 

--- a/Sources/SkillDeck/Views/Detail/SkillDetailView.swift
+++ b/Sources/SkillDeck/Views/Detail/SkillDetailView.swift
@@ -221,6 +221,14 @@ struct SkillDetailView: View {
                     .appFont(.subheadline)
                     .fontWeight(.semibold)
 
+                if case .available(_, let failedLogCount) = skillManager.codexSkillUsageScanState,
+                   failedLogCount > 0 {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .help(localized(L10nKeys.usageIncompleteHelp))
+                        .accessibilityLabel(localized(L10nKeys.usageIncompleteHelp))
+                }
+
                 Spacer()
 
                 if skillManager.codexSkillUsageScanState == .notScanned {

--- a/Tests/SkillDeckTests/CodexSkillUsageServiceTests.swift
+++ b/Tests/SkillDeckTests/CodexSkillUsageServiceTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 /// Tests for best-effort Codex skill usage reconstruction.
 final class CodexSkillUsageServiceTests: XCTestCase {
+    private let testHomeDirectory = URL(fileURLWithPath: "/Users/test", isDirectory: true)
 
     func testScanCountsTrustedToolCallsAcrossActiveAndArchivedHistory() async throws {
         let fixture = try TemporaryHistoryFixture()
@@ -37,6 +38,16 @@ final class CodexSkillUsageServiceTests: XCTestCase {
                 timestamp: "2026-08-04T10:00:00.000Z",
                 input: "sed /tmp/repository/skills/find-skills/SKILL.md"
             ),
+            // A trusted-looking directory nested inside a repository is still not a Codex skill store.
+            try makeEvent(
+                timestamp: "2026-08-04T11:00:00.000Z",
+                input: "sed /Users/test/repository/.agents/skills/lookalike/SKILL.md"
+            ),
+            // Another user's skill store is outside the configured home directory.
+            try makeEvent(
+                timestamp: "2026-08-04T12:00:00.000Z",
+                input: "sed /Users/other/.agents/skills/foreign/SKILL.md"
+            ),
             "{ malformed json",
         ]
         try writeJSONL(activeLines, to: activeDirectory.appendingPathComponent("active.jsonl"))
@@ -52,7 +63,8 @@ final class CodexSkillUsageServiceTests: XCTestCase {
         try writeJSONL(archivedLines, to: archivedDirectory.appendingPathComponent("archived.jsonl"))
 
         let service = CodexSkillUsageService(
-            historyDirectories: [activeDirectory, archivedDirectory]
+            historyDirectories: [activeDirectory, archivedDirectory],
+            homeDirectory: testHomeDirectory
         )
         let result = await service.scan()
 
@@ -60,6 +72,9 @@ final class CodexSkillUsageServiceTests: XCTestCase {
         XCTAssertEqual(result.records["find-skills"]?.detectedInvocationCount, 2)
         XCTAssertEqual(result.records["openai-docs"]?.detectedInvocationCount, 1)
         XCTAssertNil(result.records["repository"])
+        XCTAssertNil(result.records["lookalike"])
+        XCTAssertNil(result.records["foreign"])
+        XCTAssertEqual(result.failedLogCount, 0)
 
         let expectedLastUsed = ISO8601DateFormatter().date(from: "2026-08-05T10:00:00Z")
         XCTAssertEqual(result.records["find-skills"]?.lastDetectedAt, expectedLastUsed)
@@ -78,7 +93,10 @@ final class CodexSkillUsageServiceTests: XCTestCase {
         )
         try writeJSONL([event], to: historyDirectory.appendingPathComponent("plugin.jsonl"))
 
-        let result = await CodexSkillUsageService(historyDirectories: [historyDirectory]).scan()
+        let result = await CodexSkillUsageService(
+            historyDirectories: [historyDirectory],
+            homeDirectory: testHomeDirectory
+        ).scan()
 
         XCTAssertEqual(result.records["computer-use"]?.detectedInvocationCount, 1)
     }
@@ -88,9 +106,13 @@ final class CodexSkillUsageServiceTests: XCTestCase {
         defer { fixture.remove() }
 
         let missingDirectory = fixture.root.appendingPathComponent("missing", isDirectory: true)
-        let result = await CodexSkillUsageService(historyDirectories: [missingDirectory]).scan()
+        let result = await CodexSkillUsageService(
+            historyDirectories: [missingDirectory],
+            homeDirectory: testHomeDirectory
+        ).scan()
 
         XCTAssertEqual(result.scannedLogCount, 0)
+        XCTAssertEqual(result.failedLogCount, 0)
         XCTAssertTrue(result.records.isEmpty)
     }
 
@@ -119,6 +141,7 @@ final class CodexSkillUsageServiceTests: XCTestCase {
 
         let service = CodexSkillUsageService(
             historyDirectories: [historyDirectory],
+            homeDirectory: testHomeDirectory,
             cacheURL: cacheURL
         )
         let first = await service.scan()
@@ -140,6 +163,98 @@ final class CodexSkillUsageServiceTests: XCTestCase {
         let second = await service.scan()
         XCTAssertEqual(second.records["unchanged"]?.detectedInvocationCount, 1)
         XCTAssertEqual(second.records["changing"]?.detectedInvocationCount, 2)
+    }
+
+    func testScanIsolatesUnreadableChangedLogAndRetainsItsCachedEvidence() async throws {
+        let fixture = try TemporaryHistoryFixture()
+        defer { fixture.remove() }
+
+        let historyDirectory = fixture.root.appendingPathComponent("sessions", isDirectory: true)
+        let cacheURL = fixture.root.appendingPathComponent("usage-cache.json")
+        try FileManager.default.createDirectory(at: historyDirectory, withIntermediateDirectories: true)
+
+        let readableURL = historyDirectory.appendingPathComponent("readable.jsonl")
+        let unreadableURL = historyDirectory.appendingPathComponent("unreadable.jsonl")
+        try writeJSONL([
+            try makeEvent(
+                timestamp: "2026-08-01T10:00:00.000Z",
+                input: "sed /Users/test/.agents/skills/readable/SKILL.md"
+            ),
+        ], to: readableURL)
+        try writeJSONL([
+            try makeEvent(
+                timestamp: "2026-08-01T11:00:00.000Z",
+                input: "sed /Users/test/.agents/skills/unreadable/SKILL.md"
+            ),
+        ], to: unreadableURL)
+
+        let service = CodexSkillUsageService(
+            historyDirectories: [historyDirectory],
+            homeDirectory: testHomeDirectory,
+            cacheURL: cacheURL
+        )
+        let first = await service.scan()
+        XCTAssertEqual(first.records["readable"]?.detectedInvocationCount, 1)
+        XCTAssertEqual(first.records["unreadable"]?.detectedInvocationCount, 1)
+
+        try appendJSONL(
+            try makeEvent(
+                timestamp: "2026-08-02T10:00:00.000Z",
+                input: "sed /Users/test/.agents/skills/readable/SKILL.md"
+            ),
+            to: readableURL
+        )
+        try appendJSONL(
+            try makeEvent(
+                timestamp: "2026-08-02T11:00:00.000Z",
+                input: "sed /Users/test/.agents/skills/unreadable/SKILL.md"
+            ),
+            to: unreadableURL
+        )
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: unreadableURL.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: unreadableURL.path)
+        }
+
+        let partial = await service.scan()
+        XCTAssertEqual(partial.records["readable"]?.detectedInvocationCount, 2)
+        XCTAssertEqual(partial.records["unreadable"]?.detectedInvocationCount, 1)
+        XCTAssertEqual(partial.scannedLogCount, 2)
+        XCTAssertEqual(partial.failedLogCount, 1)
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: unreadableURL.path)
+        let recovered = await service.scan()
+        XCTAssertEqual(recovered.records["unreadable"]?.detectedInvocationCount, 2)
+        XCTAssertEqual(recovered.failedLogCount, 0)
+    }
+
+    func testScanWithoutCacheURLDoesNotCreateProcessTemporaryCache() async throws {
+        let fixture = try TemporaryHistoryFixture()
+        defer { fixture.remove() }
+
+        let historyDirectory = fixture.root.appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: historyDirectory, withIntermediateDirectories: true)
+        try writeJSONL([
+            try makeEvent(
+                timestamp: "2026-08-01T10:00:00.000Z",
+                input: "sed /Users/test/.agents/skills/no-cache/SKILL.md"
+            ),
+        ], to: historyDirectory.appendingPathComponent("history.jsonl"))
+
+        let before = try generatedTemporaryCacheURLs()
+        defer {
+            let after = (try? generatedTemporaryCacheURLs()) ?? []
+            for url in after.subtracting(before) {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+
+        _ = await CodexSkillUsageService(
+            historyDirectories: [historyDirectory],
+            homeDirectory: testHomeDirectory
+        ).scan()
+
+        XCTAssertEqual(try generatedTemporaryCacheURLs(), before)
     }
 
     /// Build one top-level Codex JSONL event without hand-escaping nested command strings.
@@ -167,6 +282,21 @@ final class CodexSkillUsageServiceTests: XCTestCase {
     private func writeJSONL(_ lines: [String], to url: URL) throws {
         let contents = lines.joined(separator: "\n") + "\n"
         try XCTUnwrap(contents.data(using: .utf8)).write(to: url, options: .atomic)
+    }
+
+    private func appendJSONL(_ line: String, to url: URL) throws {
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: XCTUnwrap("\(line)\n".data(using: .utf8)))
+        try handle.close()
+    }
+
+    private func generatedTemporaryCacheURLs() throws -> Set<URL> {
+        let urls = try FileManager.default.contentsOfDirectory(
+            at: FileManager.default.temporaryDirectory,
+            includingPropertiesForKeys: nil
+        )
+        return Set(urls.filter { $0.lastPathComponent.hasPrefix("SkillDeckUsageCache-") })
     }
 
     /// Each test owns a uniquely named temporary directory and removes only that exact path.

--- a/Tests/SkillDeckTests/CodexSkillUsageServiceTests.swift
+++ b/Tests/SkillDeckTests/CodexSkillUsageServiceTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import XCTest
+
+@testable import SkillDeck
+
+/// Tests for best-effort Codex skill usage reconstruction.
+final class CodexSkillUsageServiceTests: XCTestCase {
+
+    func testScanCountsTrustedToolCallsAcrossActiveAndArchivedHistory() async throws {
+        let fixture = try TemporaryHistoryFixture()
+        defer { fixture.remove() }
+
+        let activeDirectory = fixture.root.appendingPathComponent("sessions", isDirectory: true)
+        let archivedDirectory = fixture.root.appendingPathComponent("archived_sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: activeDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: archivedDirectory, withIntermediateDirectories: true)
+
+        let activeLines = [
+            // A message mentioning a trusted path is not invocation evidence because it is not a tool call.
+            try makeEvent(
+                timestamp: "2026-08-01T10:00:00.000Z",
+                payloadType: "message",
+                input: "Read /Users/test/.agents/skills/find-skills/SKILL.md"
+            ),
+            // Repeating one path inside the same tool call counts once, not once per string occurrence.
+            try makeEvent(
+                timestamp: "2026-08-02T10:00:00.000Z",
+                input: "sed /Users/test/.agents/skills/find-skills/SKILL.md /Users/test/.agents/skills/find-skills/SKILL.md"
+            ),
+            // Nested system skills use the final parent directory as their identifier.
+            try makeEvent(
+                timestamp: "2026-08-03T10:00:00.000Z",
+                input: "sed /Users/test/.codex/skills/.system/openai-docs/SKILL.md"
+            ),
+            // Repository files are intentionally ignored even when their layout includes `skills/`.
+            try makeEvent(
+                timestamp: "2026-08-04T10:00:00.000Z",
+                input: "sed /tmp/repository/skills/find-skills/SKILL.md"
+            ),
+            "{ malformed json",
+        ]
+        try writeJSONL(activeLines, to: activeDirectory.appendingPathComponent("active.jsonl"))
+
+        let archivedLines = [
+            // Function-call payloads use `arguments` instead of `input` in Codex history.
+            try makeEvent(
+                timestamp: "2026-08-05T10:00:00Z",
+                payloadType: "function_call",
+                input: "head /Users/test/.agents/skills/find-skills/SKILL.md"
+            ),
+        ]
+        try writeJSONL(archivedLines, to: archivedDirectory.appendingPathComponent("archived.jsonl"))
+
+        let service = CodexSkillUsageService(
+            historyDirectories: [activeDirectory, archivedDirectory]
+        )
+        let result = await service.scan()
+
+        XCTAssertEqual(result.scannedLogCount, 2)
+        XCTAssertEqual(result.records["find-skills"]?.detectedInvocationCount, 2)
+        XCTAssertEqual(result.records["openai-docs"]?.detectedInvocationCount, 1)
+        XCTAssertNil(result.records["repository"])
+
+        let expectedLastUsed = ISO8601DateFormatter().date(from: "2026-08-05T10:00:00Z")
+        XCTAssertEqual(result.records["find-skills"]?.lastDetectedAt, expectedLastUsed)
+    }
+
+    func testScanRecognizesPluginCacheSkillPaths() async throws {
+        let fixture = try TemporaryHistoryFixture()
+        defer { fixture.remove() }
+
+        let historyDirectory = fixture.root.appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: historyDirectory, withIntermediateDirectories: true)
+
+        let event = try makeEvent(
+            timestamp: "2026-08-06T10:00:00.000Z",
+            input: "sed /Users/test/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md"
+        )
+        try writeJSONL([event], to: historyDirectory.appendingPathComponent("plugin.jsonl"))
+
+        let result = await CodexSkillUsageService(historyDirectories: [historyDirectory]).scan()
+
+        XCTAssertEqual(result.records["computer-use"]?.detectedInvocationCount, 1)
+    }
+
+    func testScanReturnsNoCoverageWhenHistoryIsMissing() async throws {
+        let fixture = try TemporaryHistoryFixture()
+        defer { fixture.remove() }
+
+        let missingDirectory = fixture.root.appendingPathComponent("missing", isDirectory: true)
+        let result = await CodexSkillUsageService(historyDirectories: [missingDirectory]).scan()
+
+        XCTAssertEqual(result.scannedLogCount, 0)
+        XCTAssertTrue(result.records.isEmpty)
+    }
+
+    func testScanReusesUnchangedFilesAndRescansOnlyChangedFiles() async throws {
+        let fixture = try TemporaryHistoryFixture()
+        defer { fixture.remove() }
+
+        let historyDirectory = fixture.root.appendingPathComponent("sessions", isDirectory: true)
+        let cacheURL = fixture.root.appendingPathComponent("usage-cache.json")
+        try FileManager.default.createDirectory(at: historyDirectory, withIntermediateDirectories: true)
+
+        let unchangedURL = historyDirectory.appendingPathComponent("archived.jsonl")
+        let changingURL = historyDirectory.appendingPathComponent("active.jsonl")
+        try writeJSONL([
+            try makeEvent(
+                timestamp: "2026-08-01T10:00:00.000Z",
+                input: "sed /Users/test/.agents/skills/unchanged/SKILL.md"
+            ),
+        ], to: unchangedURL)
+        try writeJSONL([
+            try makeEvent(
+                timestamp: "2026-08-02T10:00:00.000Z",
+                input: "sed /Users/test/.agents/skills/changing/SKILL.md"
+            ),
+        ], to: changingURL)
+
+        let service = CodexSkillUsageService(
+            historyDirectories: [historyDirectory],
+            cacheURL: cacheURL
+        )
+        let first = await service.scan()
+        XCTAssertEqual(first.records["unchanged"]?.detectedInvocationCount, 1)
+        XCTAssertEqual(first.records["changing"]?.detectedInvocationCount, 1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheURL.path))
+
+        // Appending changes the active log fingerprint. The archived file remains unchanged and
+        // must still contribute exactly once when its cached per-file result is merged.
+        let appendedEvent = try makeEvent(
+            timestamp: "2026-08-03T10:00:00.000Z",
+            input: "sed /Users/test/.agents/skills/changing/SKILL.md"
+        ) + "\n"
+        let handle = try FileHandle(forWritingTo: changingURL)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: XCTUnwrap(appendedEvent.data(using: .utf8)))
+        try handle.close()
+
+        let second = await service.scan()
+        XCTAssertEqual(second.records["unchanged"]?.detectedInvocationCount, 1)
+        XCTAssertEqual(second.records["changing"]?.detectedInvocationCount, 2)
+    }
+
+    /// Build one top-level Codex JSONL event without hand-escaping nested command strings.
+    private func makeEvent(
+        timestamp: String,
+        payloadType: String = "custom_tool_call",
+        input: String
+    ) throws -> String {
+        var payload: [String: Any] = ["type": payloadType]
+        if payloadType == "function_call" {
+            payload["arguments"] = input
+        } else {
+            payload["input"] = input
+        }
+
+        let object: [String: Any] = [
+            "timestamp": timestamp,
+            "type": "response_item",
+            "payload": payload,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return try XCTUnwrap(String(data: data, encoding: .utf8))
+    }
+
+    private func writeJSONL(_ lines: [String], to url: URL) throws {
+        let contents = lines.joined(separator: "\n") + "\n"
+        try XCTUnwrap(contents.data(using: .utf8)).write(to: url, options: .atomic)
+    }
+
+    /// Each test owns a uniquely named temporary directory and removes only that exact path.
+    private struct TemporaryHistoryFixture {
+        let root: URL
+
+        init() throws {
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("SkillDeckUsageTests-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        }
+
+        func remove() {
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+}


### PR DESCRIPTION
Closes #62

## 背景

用户安装较多 Skill 后，很难判断哪些真正使用过。本 PR 在 Skill 详情页中可视化 Codex 本地历史记录中的使用情况。

## 功能

- 展示检测到的使用次数和最近使用时间
- 使用通用 `Usage` 区域按 Agent 分组展示，Codex 复用现有图标和品牌色
- 支持手动扫描与刷新
- 扫描 Codex 活跃及归档的本地会话记录
- 仅统计结构化工具调用中可信 Skill 路径的使用记录
- 使用增量缓存减少重复扫描
- 扫描过程不会上传原始日志或统计缓存

统计结果仅供参考：日志可能缺失，且暂未覆盖其他 Agent 和项目引用，因此不用于判断 Skill 是否可以安全删除。

## 统计原理

Codex 运行时会将工具调用写入本地 JSONL 会话日志。本实现不会直接搜索 Skill 名称，而是：

1. 快速筛选包含 `SKILL.md` 的候选日志行
2. 解析 JSON，仅接受 `response_item` 中的 `custom_tool_call` 或 `function_call`
3. 仅提取当前用户可信 Skill 目录下的标准化 `SKILL.md` 路径，并由父目录得到 Skill ID
4. 同一条结构化调用中的同一 Skill 最多计数一次，同时记录调用时间

例如下面的调用会给 `diagnose` 增加一次：

```json
{
  "type": "response_item",
  "payload": {
    "type": "custom_tool_call",
    "input": ".../.agents/skills/diagnose/SKILL.md..."
  }
}
```

普通聊天文本、完成通知和工具输出中即使出现 Skill 名称或路径，也不会计数。

## Review 意见与解决思路

### 1. 单个日志失败会使整批统计失效

- 批量 `grep` 失败后递归二分日志集合，定位具体失败文件
- 合并其余成功日志的结果，不再丢弃整批统计
- 对暂时不可读的日志保留已有缓存，并在下次刷新时重试
- 通过 `failedLogCount` 向 UI 暴露不完整状态，并显示黄色警告及说明

### 2. 子串路径校验可能误报

- 将候选路径标准化后锚定到初始化时配置的用户主目录
- 分别校验 `~/.agents/skills`、`~/.codex/skills`、`~/.codex/skills/.system` 和插件缓存的明确目录结构
- 拒绝项目内仿冒目录、备份目录、其他用户目录及非标准层级

### 3. 测试默认缓存会泄漏临时文件

- 测试初始化器的 `cacheURL` 默认为 `nil`，表示不持久化
- 只有生产初始化器和显式传入缓存路径的测试才会读写缓存
- 新增回归测试验证进程临时目录不会产生缓存文件

## 后续扩展

不同 Agent 的日志位置、格式和调用证据并不统一。后续可以抽象 `SkillUsageProvider`，由 Codex、Claude Code、Gemini CLI、OpenCode 等分别实现扫描规则。

当前 UI 已按 Agent 分组，Codex 是第一个统计 Provider。后续可以继续增加其他 Agent，并统一展示使用次数、最近使用时间以及“未扫描 / 暂不支持 / 可用”状态；没有可靠数据来源时显示 `—`，而不是误报为 `0`。

## 本地验证

真实调用前，`diagnose` 的检测次数为 223：

![调用前：diagnose 223 次](https://raw.githubusercontent.com/YanMinLiOfficial/SkillDeck/f5f1a55e8378f849bf7aa3fedb905e96f741df49/evidence/04-agent-usage-baseline-223.png)

刷新期间显示扫描状态：

![扫描本地 Codex 历史](https://raw.githubusercontent.com/YanMinLiOfficial/SkillDeck/f5f1a55e8378f849bf7aa3fedb905e96f741df49/evidence/05-agent-usage-scanning.png)

真实调用并刷新后，检测次数增加到 224：

![调用后：diagnose 224 次](https://raw.githubusercontent.com/YanMinLiOfficial/SkillDeck/f5f1a55e8378f849bf7aa3fedb905e96f741df49/evidence/06-agent-usage-result-224.png)

审查修复专项测试（6/6）：

![审查修复专项测试](https://raw.githubusercontent.com/YanMinLiOfficial/SkillDeck/d4437da0fa075d6543db224e9e93066fac90db09/evidence/07-review-fix-targeted-tests.png)

完整测试套件（187/187）：

![完整测试套件](https://raw.githubusercontent.com/YanMinLiOfficial/SkillDeck/d4437da0fa075d6543db224e9e93066fac90db09/evidence/08-review-fix-full-tests.png)

隔离夹具验证部分日志失败时仍保留成功统计，并显示不完整警告；红框为本 PR 的 Usage 区域：

![部分日志失败警告](https://raw.githubusercontent.com/YanMinLiOfficial/SkillDeck/d4437da0fa075d6543db224e9e93066fac90db09/evidence/09-review-fix-incomplete-warning.png)

## 测试

- `swift test --filter CodexSkillUsageServiceTests`：6 个测试全部通过
- `swift test`：187 个测试全部通过
- 使用约 1.8 GB、191 个真实 Codex 日志测试
- `diagnose` 的统计次数经真实调用后从 223 增加到 224
- 完整扫描约 33 秒，增量刷新约 4 秒
- 已验证扫描前、扫描中、扫描完成以及部分日志失败的界面状态
